### PR TITLE
[scripts]: Make the bash scripts a bit more portable

### DIFF
--- a/scripts/adv/gen_other_builds
+++ b/scripts/adv/gen_other_builds
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
 # GLOBAL VARIABLES

--- a/scripts/adv/test_all_other_builds
+++ b/scripts/adv/test_all_other_builds
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
 # GLOBAL VARIABLES

--- a/scripts/bash_includes/script_utils
+++ b/scripts/bash_includes/script_utils
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
 ############################################

--- a/scripts/bash_includes/tc/cmake_download
+++ b/scripts/bash_includes/tc/cmake_download
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
 # ---------------------------------------------------------------

--- a/scripts/bash_includes/tc/gcc_tc
+++ b/scripts/bash_includes/tc/gcc_tc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
 # ---------------------------------------------------------------

--- a/scripts/bash_includes/tc/install_pkgs
+++ b/scripts/bash_includes/tc/install_pkgs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
 # ---------------------------------------------------------------

--- a/scripts/build_scripts/create_empty_img_if_necessary
+++ b/scripts/build_scripts/create_empty_img_if_necessary
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ ! -f $1 ]; then
    dd status=none if=/dev/zero of=$1 bs=1K count=$2

--- a/scripts/build_toolchain
+++ b/scripts/build_toolchain
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
 # GLOBAL VARIABLES

--- a/scripts/cmake_run
+++ b/scripts/cmake_run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
 # Constants

--- a/scripts/dev/virtualbox_create_vmdk_loop0
+++ b/scripts/dev/virtualbox_create_vmdk_loop0
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rawImg="tilck.img"
 vmdk="tilck.vmdk"

--- a/scripts/templates/build_fatpart
+++ b/scripts/templates/build_fatpart
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
 # Exit on any error

--- a/scripts/templates/build_test_fatpart
+++ b/scripts/templates/build_test_fatpart
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
 # Exit on any error

--- a/scripts/templates/generate_coverage_report
+++ b/scripts/templates/generate_coverage_report
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
 # If TEST_GCOV is empty/unset but TRAVIS/CIRCLECI is set, exit

--- a/scripts/templates/qemu/debug_run_qemu
+++ b/scripts/templates/qemu/debug_run_qemu
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BUILD_DIR="@CMAKE_BINARY_DIR@"
 $BUILD_DIR/run_multiboot_nokvm_qemu -S "$@"

--- a/scripts/templates/qemu/run_efi_nokvm_qemu32
+++ b/scripts/templates/qemu/run_efi_nokvm_qemu32
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BUILD_DIR="@CMAKE_BINARY_DIR@"
 f="@GPT_IMG_FILE@"

--- a/scripts/templates/qemu/run_efi_nokvm_qemu64
+++ b/scripts/templates/qemu/run_efi_nokvm_qemu64
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BUILD_DIR="@CMAKE_BINARY_DIR@"
 f="@GPT_IMG_FILE@"

--- a/scripts/templates/qemu/run_efi_qemu32
+++ b/scripts/templates/qemu/run_efi_qemu32
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BUILD_DIR="@CMAKE_BINARY_DIR@"
 

--- a/scripts/templates/qemu/run_efi_qemu64
+++ b/scripts/templates/qemu/run_efi_qemu64
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BUILD_DIR="@CMAKE_BINARY_DIR@"
 

--- a/scripts/templates/qemu/run_multiboot_qemu
+++ b/scripts/templates/qemu/run_multiboot_qemu
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if uname -a | grep Microsoft &> /dev/null; then
    echo "It looks like you're using WSL (a.k.a. \"Bash for Windows\"): "

--- a/scripts/templates/qemu/run_nokvm_qemu
+++ b/scripts/templates/qemu/run_nokvm_qemu
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BUILD_DIR=@CMAKE_BINARY_DIR@
 qemu-system-i386 @QEMU_COMMON_OPTS@ -s @QEMU_RAM_OPT@            \

--- a/scripts/templates/qemu/run_qemu
+++ b/scripts/templates/qemu/run_qemu
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BUILD_DIR="@CMAKE_BINARY_DIR@"
 


### PR DESCRIPTION
Use `#!/usr/bin/env bash`, instead of `#!/bin/bash` as bash is not in the `/bin/` dir in all *nix systems.