### PR TITLE
[syscalls] Support NULL u_times param in sys_utimes()

### DIFF
--- a/kernel/fs/vfs/vfs.c
+++ b/kernel/fs/vfs/vfs.c
@@ -581,6 +581,9 @@ vfs_utimens_impl(struct fs *fs,
    if (!fs->fsops->futimens)
       return -EROFS;
 
+   if (!p->fs_path.inode)
+      return -ENOENT;
+
    return fs->fsops->futimens(fs, p->fs_path.inode, ts);
 }
 


### PR DESCRIPTION
The corner case was simply not handled due to an oversight.
In addition to that, this patch fixes vfs_utimens_impl() in vfs.c to
handle correctly the case where the path is non-existent.