### PR TITLE
Added Lua support

### DIFF
--- a/other/cmake/config_fatpart
+++ b/other/cmake/config_fatpart
@@ -11,3 +11,4 @@ extra = @USERAPPS_extra@
 fbtest = @USERAPPS_fbtest@
 ncapp = @USERAPPS_ncapp@
 termtest = @USERAPPS_termtest@
+lua = @EXTRA_LUA@

--- a/other/cmake/extra_apps.cmake
+++ b/other/cmake/extra_apps.cmake
@@ -26,6 +26,10 @@ if (EXISTS ${TCROOT}/${ARCH}/tree_cmd)
    message(STATUS "EXTRA_TREE_CMD: ${EXTRA_TREE_CMD}")
 endif()
 
+if (EXISTS ${TCROOT}/${ARCH}/lua)
+   set(EXTRA_LUA OFF CACHE BOOL "Load LUA in Tilck")
+   message(STATUS "EXTRA_LUA: ${EXTRA_LUA}")
+endif()
 
 if (EXTRA_VIM)
    set(EXTRA_VIM_ENABLED "1")
@@ -50,4 +54,8 @@ endif()
 
 if (EXTRA_TREE_CMD)
    set(EXTRA_TREE_CMD_ENABLED "1")
+endif()
+
+if (EXTRA_LUA)
+   set(EXTRA_LUA_ENABLED "1")
 endif()

--- a/other/toolchain_builds.yml
+++ b/other/toolchain_builds.yml
@@ -49,6 +49,8 @@ steps:
     displayName: "[toolchain] Build vim"
   - script: sudo -E ./scripts/build_toolchain -s build_tfblib
     displayName: "[toolchain] Build tfblib"
+  - script: sudo -E ./scripts/build_toolchain -s build_lua
+    displayName: "[toolchain] Build Lua"
   - script: make -j
     displayName: Build the kernel
   - script: make -j gtests

--- a/scripts/bash_includes/tc/lua
+++ b/scripts/bash_includes/tc/lua
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-2-Clause
+
+function download_lua {
+   local version="5.4.1"
+   local filename="lua"
+   local tarname="lua-$version.tar.gz"
+   local url="https://www.lua.org/ftp/"
+
+   download_file_in_cache "$url" "$tarname" lua
+   extract_cachefile_tar_gz "$tarname" "lua-$version" "lua"
+}
+
+all_funcs_list+=(build_lua)
+function build_lua {
+
+   pushd $ARCH
+   reset_cc_vars
+
+   show_work_on_component_msg "LUA"
+
+   if ! [ -d "lua" ]; then
+
+      download_lua
+      cd lua
+
+      if [[ "$HOST_ARCH" != "$BUILD_ARCH" ]]; then
+
+         # Case HOST_ARCH == ARCH
+         # Note: if HOST_ARCH not in [BUILD_ARCH, ARCH], we fail earlier.
+         #
+         # Note: NOT TESTED yet.
+         # Remember: this scenario (building on $ARCH) is _not_ officially
+         # supported.
+
+         export SYS_CC="$CC"
+         export SYS_CXX="$CXX"
+         export CC_POST_FLAGS="-specs $MUSL_INSTALL/lib/musl-gcc.specs"
+      else
+         set_cc_vars_to_tc
+      fi
+
+      echo "Building lua..."
+      make clean
+      #build lua and luac static binaries
+      local flags=""
+      flags="$flags CC=\"$CC\" MYCFLAGS=\"-std=gnu99\""
+      flags="$flags AR=\"$AR rcu\" RANLIB=\"$RANLIB\""
+      flags="$flags MYLDFLAGS=\"-static\""
+      run_command2 "make $flags" build.log
+
+      echo "Lua built successfully"
+
+   else
+      show_skip_component_msg "LUA"
+   fi
+
+   popd
+}

--- a/scripts/templates/build_fatpart
+++ b/scripts/templates/build_fatpart
@@ -257,6 +257,21 @@ function add_tree_cmd {
    link_or_copy $tc/$arch/tree_cmd/tree usr/bin
 }
 
+function add_lua {
+
+   if [ -z "@EXTRA_LUA_ENABLED@" ]; then
+      return
+   fi
+
+   if [ -f $tc/$arch/lua/src/lua ]; then
+      link_or_copy $tc/$arch/lua/src/lua bin/
+   fi
+
+   if [ -f $tc/$arch/lua/src/luac ]; then
+      link_or_copy $tc/$arch/lua/src/luac bin/
+   fi
+}
+
 function make_fatpart {
 
    create_fatpart_if_necessary
@@ -312,5 +327,6 @@ add_micropython
 add_fbdoom
 add_vim
 add_tree_cmd
+add_lua
 
 make_fatpart


### PR DESCRIPTION
Hey!
 I got interested in this project and I would like to make a small contribution.
I am making this PR to add Lua interpreter support. I have added all the necessary scripts in `scripts/bash_includes/tc/lua` and also I have added `add_lua` routine in `templates/build_fatpart` .

As you know Lua is a tiny interpreter and it is a cool nice feature to have in the toolchain. Having Lua in the toolchain would allow anyone to build cool new features with Lua scripting language. (Most of the hobby operating systems I have seen has a Lua port).

None of the kernel functions are modified as a part of this PR.

I have tried my best to maintain the same coding standards as yours, so that there will be a uniformity.
Please review the PR, I am happy to make any changes you request.

Regards,
Prasanna