### PR TITLE
[scripts] Fix WSL detection via uname

### DIFF
--- a/scripts/templates/qemu/run_efi_qemu32
+++ b/scripts/templates/qemu/run_efi_qemu32
@@ -2,7 +2,7 @@
 
 BUILD_DIR="@CMAKE_BINARY_DIR@"
 
-if uname -a | grep Microsoft &> /dev/null; then
+if uname -a | grep -i microsoft &> /dev/null; then
    echo "It looks like you're using WSL (a.k.a. \"Bash for Windows\"): "
    echo "therefore, KVM is not available."
    echo "Just run the *nokvm* version of this script."

--- a/scripts/templates/qemu/run_efi_qemu64
+++ b/scripts/templates/qemu/run_efi_qemu64
@@ -2,7 +2,7 @@
 
 BUILD_DIR="@CMAKE_BINARY_DIR@"
 
-if uname -a | grep Microsoft &> /dev/null; then
+if uname -a | grep -i microsoft &> /dev/null; then
    echo "It looks like you're using WSL (a.k.a. \"Bash for Windows\"): "
    echo "therefore, KVM is not available."
    echo "Just run the *nokvm* version of this script."

--- a/scripts/templates/qemu/run_multiboot_qemu
+++ b/scripts/templates/qemu/run_multiboot_qemu
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if uname -a | grep Microsoft &> /dev/null; then
+if uname -a | grep -i microsoft &> /dev/null; then
    echo "It looks like you're using WSL (a.k.a. \"Bash for Windows\"): "
    echo "therefore, KVM is not available."
    echo "Just run the *nokvm* version of this script."

--- a/scripts/templates/qemu/run_qemu
+++ b/scripts/templates/qemu/run_qemu
@@ -2,7 +2,7 @@
 
 BUILD_DIR="@CMAKE_BINARY_DIR@"
 
-if uname -a | grep Microsoft &> /dev/null; then
+if uname -a | grep -i microsoft &> /dev/null; then
    echo "It looks like you're using WSL (a.k.a. \"Bash for Windows\"): "
    echo "therefore, KVM is not available."
    echo "Just run the *nokvm* version of this script."


### PR DESCRIPTION
I am using Windows Subsystem for Linux (version 2), and several scripts in `build/` could not detect that to warn me that I cannot use KVM. The reason is that in my case the output of `uname -a` contains `microsoft` (completely lowercase) rather than `Microsoft`:

```
$ uname -a
Linux DESKTOP-78BKHO2 5.4.72-microsoft-standard-WSL2 #1 SMP Wed Oct 28 23:40:43 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
```

I have changed the scripts so that they do a case-independent search for "microsoft", and now they prevent me from running KVM scripts.