### PR TITLE
[vscode] Fix errors in settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -198,13 +198,12 @@
       "valarray": "c",
       "variant": "c",
       "bit": "c",
-      "netfwd": "c",
-      "signal.h": "c"
+      "signal.h": "c",
       "netfwd": "c",
       "tracing.h": "c",
       "mod_tracing.h": "c",
       "devshell.h": "c",
-      "utils.h": "c"
+      "utils.h": "c",
    },
-   "python.pythonPath": "/usr/bin/python3"
+   "python.pythonPath": "/usr/bin/python3",
 }


### PR DESCRIPTION
The missing comma on line 201 was preventing changes to the file itself, more specifically when trying to change linter