### PR TITLE
[misc]Compile-out print_banner_line() and show_tilck_logo() when KERN…

### DIFF
--- a/kernel/misc.c
+++ b/kernel/misc.c
@@ -31,6 +31,7 @@ const ulong init_st_begin = (ulong)&kernel_initial_stack;
 const ulong init_st_end   = (ulong)&kernel_initial_stack + KERNEL_STACK_SIZE;
 #endif
 
+#ifdef KERNEL_SHOW_LOGO
 static void print_banner_line(const u8 *s)
 {
    printk(NO_PREFIX "\033(0");
@@ -70,6 +71,7 @@ static void show_tilck_logo(void)
       print_banner_line((u8 *)banner[i]);
    }
 }
+#endif
 
 static void
 show_system_info(void)


### PR DESCRIPTION
Hi, I just edited the `kernel/misc.c` file, and added the `#ifdef KERNEL_SHOW_LOGO` on line 34 and `#endif` on line 74. I ran `ccmake build` and re-configure for setting `KERNEL_SHOW_LOGO` to `OFF`. Afther that I build the tilc and gtests, Don't occur with any problem and logo did not printed. Before commit I set back the `KERNEL_SHOW_LOGO` to `ON` again (I think showing the logo is the default option and after testing the if block works I set it back with `ccmake build`).