### PR TITLE
[cmake] Patch with TOOL_WS each module linked to gtests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,6 +607,7 @@ include(other/cmake/compiler_flags.cmake)
 # Include the funcs for building the kernel modules, used both by the kernel
 # and the gtests targets.
 
+include(other/cmake/wrapped_syms.cmake)
 include(other/cmake/build_modules.cmake)
 
 foreach (opt ${kernel_opts_list})

--- a/other/cmake/wrapped_syms.cmake
+++ b/other/cmake/wrapped_syms.cmake
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: BSD-2-Clause
+cmake_minimum_required(VERSION 3.2)
+
+set(
+   WRAPPED_SYMS
+
+   assert_failed
+   not_reached
+   not_implemented
+   tilck_vprintk
+   kmutex_lock
+   kmutex_unlock
+   fat_ramdisk_prepare_for_mmap
+   wth_create_thread_for
+   wth_wakeup
+   check_in_irq_handler
+   general_kmalloc
+   general_kfree
+   kmalloc_get_first_heap
+   vfs_dup
+   vfs_close
+   use_kernel_arg
+
+   experiment_bar
+   experiment_foo
+)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -34,31 +34,6 @@ set_target_properties(
 )
 
 set(LIB_KERNEL "libkernel_test_patched.a")
-set(TOOL_WS ${CMAKE_BINARY_DIR}/scripts/weaken_syms)
-
-set(
-   WRAPPED_SYMS
-
-   assert_failed
-   not_reached
-   not_implemented
-   tilck_vprintk
-   kmutex_lock
-   kmutex_unlock
-   fat_ramdisk_prepare_for_mmap
-   wth_create_thread_for
-   wth_wakeup
-   check_in_irq_handler
-   general_kmalloc
-   general_kfree
-   kmalloc_get_first_heap
-   vfs_dup
-   vfs_close
-   use_kernel_arg
-
-   experiment_bar
-   experiment_foo
-)
 
 add_custom_command(
 
@@ -140,5 +115,5 @@ target_link_libraries(gtests ${GMOCK_TC_BUILD_DIR}/lib/libgmock.a)
 target_link_libraries(gtests ${GMOCK_TC_BUILD_DIR}/lib/libgmock_main.a)
 target_link_libraries(gtests pthread)
 target_link_libraries(gtests ${CMAKE_CURRENT_BINARY_DIR}/${LIB_KERNEL})
-build_all_modules(gtests "_noarch")
+build_all_modules(gtests "_noarch" TRUE)
 target_link_libraries(gtests ${CMAKE_CURRENT_BINARY_DIR}/${LIB_KERNEL})

--- a/tests/unit/mock_experiments.cpp
+++ b/tests/unit/mock_experiments.cpp
@@ -14,7 +14,7 @@ using namespace testing;
  * Instructions:
  *
  *    1. add all the functions that we would like to mock in the WRAPPED_SYMS
- *       list in tests/unit/CMakeLists.txt
+ *       list in other/cmake/wrapped_syms.cmake
  *
  *    2. add all of those functions in tests/unit/mocked_funcs.h, with their
  *       correct signature


### PR DESCRIPTION
When the symbol weakening was introduced in Tilck to allow wrapping of symbols in the same translation unit, the TOOL_WS (weaken_syms) was run only against the main `kernel_for_test` static library. Now that the technology proved to be useful in practice with GMock, it's time to patch also the _noarch static libraries generated by modules that are linked to the gtest executable. This will allow unit tests to mock symbols in all the whitelisted "noarch" modules. Currently they are:

  - console
  - tracing
  - sysfs