### PR TITLE
[gtest] add tests for tracing functions (#146)

### DIFF
--- a/include/tilck/kernel/test/tracing.h
+++ b/include/tilck/kernel/test/tracing.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#pragma once
+
+#include <tilck/mods/tracing.h>
+STATIC bool simple_wildcard_match(const char *str, const char *expr);
+STATIC int set_traced_syscalls_int(const char *str);
+
+extern bool *traced_syscalls;
+extern char *traced_syscalls_str;

--- a/modules/tracing/tracing.c
+++ b/modules/tracing/tracing.c
@@ -40,7 +40,7 @@ static const struct syscall_info **syscalls_info;
 static s8 (*params_slots)[MAX_SYSCALLS][6];
 static s8 *syscalls_fmts;
 
-static char *traced_syscalls_str;
+STATIC char *traced_syscalls_str;
 static int traced_syscalls_count;
 
 bool *traced_syscalls;
@@ -634,7 +634,7 @@ get_traced_syscalls_count(void)
  *    ab*c     matches NOTHING because '*' must be the last char, if present.
  *
  */
-static bool
+STATIC bool
 simple_wildcard_match(const char *str, const char *expr)
 {
    for (; *str && *expr; str++, expr++) {
@@ -657,7 +657,7 @@ simple_wildcard_match(const char *str, const char *expr)
    return false; /* not a match */
 }
 
-static int
+STATIC int
 handle_sys_trace_arg(const char *arg)
 {
    struct bintree_walk_ctx ctx;
@@ -691,7 +691,7 @@ handle_sys_trace_arg(const char *arg)
    return 0;
 }
 
-static int
+STATIC int
 set_traced_syscalls_int(const char *str)
 {
    const size_t len = strlen(str);

--- a/other/cmake/wrapped_syms.cmake
+++ b/other/cmake/wrapped_syms.cmake
@@ -20,6 +20,7 @@ set(
    vfs_dup
    vfs_close
    use_kernel_arg
+   handle_sys_trace_arg
 
    experiment_bar
    experiment_foo

--- a/tests/unit/mocked_funcs.h
+++ b/tests/unit/mocked_funcs.h
@@ -17,3 +17,4 @@ DEF_0(real, experiment_bar, bool)
 DEF_1(real, experiment_foo, int, int)
 DEF_2(real, vfs_dup, int, fs_handle, fs_handle *)
 DEF_1(real, vfs_close, void, fs_handle)
+DEF_1(real, handle_sys_trace_arg, int , const char *);

--- a/tests/unit/tracing_test.cpp
+++ b/tests/unit/tracing_test.cpp
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "mocking.h"
+
+using namespace testing;
+
+extern "C" {
+   #include <tilck/kernel/test/tracing.h>
+}
+
+
+class tracing_mock : public KernelSingleton {
+public:
+   MOCK_METHOD(int, handle_sys_trace_arg, (const char *arg), (override));
+};
+
+TEST(simple_wildcard_match, basic)
+{
+   ASSERT_TRUE(simple_wildcard_match("test string", "test string"));
+   ASSERT_TRUE(simple_wildcard_match("test string", "test string*"));
+   ASSERT_TRUE(simple_wildcard_match("test string", "tes? string"));
+   ASSERT_TRUE(simple_wildcard_match("test string", "test *"));
+   ASSERT_FALSE(simple_wildcard_match("test string", "test strin1"));
+   ASSERT_FALSE(simple_wildcard_match("test string", "te*t"));
+   ASSERT_FALSE(simple_wildcard_match("test string", "test string1"));
+}
+
+TEST(set_traced_syscalls_int, basic)
+{
+   tracing_mock mock;
+   char tracing_str[TRACED_SYSCALLS_STR_LEN+1];
+   bool traced_syscalls_mock[MAX_SYSCALLS] = {1};
+
+   memset((void *) tracing_str, 'a', TRACED_SYSCALLS_STR_LEN);
+   tracing_str[TRACED_SYSCALLS_STR_LEN] = '\0';
+   traced_syscalls = traced_syscalls_mock;
+   traced_syscalls_str = tracing_str;
+
+   ASSERT_EQ(set_traced_syscalls_int(tracing_str), -ENAMETOOLONG);
+
+   tracing_str[TRACED_SYSCALLS_STR_LEN-1] = '\0';
+   ASSERT_EQ(set_traced_syscalls_int(tracing_str), -ENAMETOOLONG);
+
+   EXPECT_CALL(mock, handle_sys_trace_arg(_))
+      .WillOnce(Return(1));
+   ASSERT_EQ(set_traced_syscalls_int(",,,"), 1);
+
+   EXPECT_CALL(mock, handle_sys_trace_arg(_))
+      .WillOnce(Return(1));
+   ASSERT_EQ(set_traced_syscalls_int("abc"), 1);
+
+   EXPECT_CALL(mock, handle_sys_trace_arg(_))
+      .WillOnce(Return(0));
+   ASSERT_EQ(set_traced_syscalls_int("abc"), 0);
+
+   EXPECT_CALL(mock, handle_sys_trace_arg(_))
+      .WillRepeatedly(Return(0));
+   ASSERT_EQ(set_traced_syscalls_int("a, b, c"), 0);
+
+   traced_syscalls = NULL;
+   traced_syscalls_str = NULL;
+}


### PR DESCRIPTION
 Closes #146. Codecov report [here](https://app.codecov.io/gh/michelececcacci/tilck/blob/addtest/modules/tracing/tracing.c/). Reached 100% coverage just with unit tests, but we may need more extensive testing.