### PR TITLE
[64-bit] Use separate vaddrs for reading phy. mem. and for the kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -542,9 +542,10 @@ if (${ARCH} STREQUAL "i386")
    set(ARCH_BITS        32)
 
    # Fundamental kernel MM constants
-   set(KERNEL_BASE_VA     0xC0000000)  # Better not touch!
+   set(BASE_VA            0xC0000000)  # Better not touch!
    set(KERNEL_PADDR       0x00100000)  # Better not touch!
    set(LINEAR_MAPPING_MB         896)  # Better not touch!
+   set(KERNEL_VADDR       0xC0100000)
 
 elseif(${ARCH} STREQUAL "x86_64")
 
@@ -558,9 +559,10 @@ elseif(${ARCH} STREQUAL "x86_64")
    set(ARCH_BITS        64)
 
    # Fundamental kernel MM constants
-   set(KERNEL_BASE_VA      0x100000000000)  # +16 TB
-   set(KERNEL_PADDR            0x00100000)  # Better not touch!
-   set(LINEAR_MAPPING_MB             4096)  # Might be updated.
+   set(BASE_VA                0x100000000000)  # +16 TB
+   set(KERNEL_PADDR               0x00100000)  # Better not touch!
+   set(LINEAR_MAPPING_MB                4096)  # Might be updated.
+   set(KERNEL_VADDR       0xFFFFFFFF80000000)
 
 else()
 

--- a/boot/common/main_common_logic.c
+++ b/boot/common/main_common_logic.c
@@ -101,7 +101,7 @@ check_elf_kernel(void)
       if (phdr->p_type != PT_LOAD)
          continue;
 
-      CHECK(phdr->p_vaddr >= KERNEL_BASE_VA);
+      CHECK(phdr->p_vaddr >= BASE_VA);
       CHECK(phdr->p_paddr >= KERNEL_PADDR);
    }
 

--- a/boot/common/simple_elf_loader.c
+++ b/boot/common/simple_elf_loader.c
@@ -47,7 +47,7 @@ void *simple_elf_loader(void *elf)
                    phdr->p_vaddr + phdr->p_filesz))
       {
          /*
-          * If e_entry is a vaddr (address >= KERNEL_BASE_VA), we need to
+          * If e_entry is a vaddr (address >= KERNEL_VADDR), we need to
           * calculate its paddr because here paging is OFF. Therefore,
           * compute its offset from the beginning of the segment and add it
           * to the paddr of the segment.

--- a/boot/efi/ramdisk.c
+++ b/boot/efi/ramdisk.c
@@ -133,7 +133,7 @@ LoadRamdisk_AllocMem(struct load_ramdisk_ctx *ctx)
 
    /*
     * Because Tilck is 32-bit and it maps the first LINEAR_MAPPING_SIZE of
-    * physical memory at KERNEL_BASE_VA, we really cannot accept ANY address
+    * physical memory at BASE_VA, we really cannot accept ANY address
     * in the 64-bit space, because from Tilck we won't be able to read from
     * there. The address of the ramdisk we actually be at most:
     *

--- a/config/config_global.h
+++ b/config/config_global.h
@@ -27,8 +27,9 @@
 
 #define KERNEL_STACK_PAGES     @KERNEL_STACK_PAGES@
 #define KERNEL_PADDR           @KERNEL_PADDR@
-#define KERNEL_BASE_VA         @KERNEL_BASE_VA@
+#define BASE_VA                @BASE_VA@
 #define LINEAR_MAPPING_MB      @LINEAR_MAPPING_MB@UL
+#define KERNEL_VADDR           @KERNEL_VADDR@
 
 #define ARCH_BITS              @ARCH_BITS@
 
@@ -61,19 +62,19 @@
 
 #if defined(TESTING) || defined(KERNEL_TEST)
 
-   extern void *kernel_va;
+   extern void *base_va;
 
    /* For the unit tests, we need to override the following defines */
-   #undef KERNEL_BASE_VA
+   #undef BASE_VA
    #undef LINEAR_MAPPING_MB
 
-   #define KERNEL_BASE_VA             ((ulong)kernel_va)
+   #define BASE_VA                    ((ulong)base_va)
    #define LINEAR_MAPPING_MB          (128u)
 
 #endif
 
 #define LINEAR_MAPPING_SIZE        (LINEAR_MAPPING_MB << 20)
-#define LINEAR_MAPPING_END         (KERNEL_BASE_VA + LINEAR_MAPPING_SIZE)
+#define LINEAR_MAPPING_END         (BASE_VA + LINEAR_MAPPING_SIZE)
 
 /* Constants that have no reason to be changed */
 #define FREE_MEM_POISON_VAL    0xFAABCAFE

--- a/config/config_mm.h
+++ b/config/config_mm.h
@@ -36,7 +36,7 @@
 
 #define USER_VDSO_VADDR  (LINEAR_MAPPING_END)
 
-#define USERMODE_VADDR_END   (KERNEL_BASE_VA) /* biggest user vaddr + 1 */
+#define USERMODE_VADDR_END          (BASE_VA) /* biggest user vaddr + 1 */
 #define MAX_BRK                  (0x40000000) /* +1 GB (virtual memory) */
 #define USER_MMAP_BEGIN               MAX_BRK /* +1 GB (virtual memory) */
 #define USER_MMAP_MIN_SZ            (16 * MB)

--- a/config/mod_fb.h
+++ b/config/mod_fb.h
@@ -35,4 +35,4 @@
 
 
 #define FBCON_OPT_FUNCS_MIN_FREE_HEAP                        (16 * MB)
-#define FAILSAFE_FB_VADDR          (KERNEL_BASE_VA + (1024 - 64) * MB)
+#define FAILSAFE_FB_VADDR                 (BASE_VA + (1024 - 64) * MB)

--- a/include/tilck/kernel/paging.h
+++ b/include/tilck/kernel/paging.h
@@ -32,8 +32,17 @@
  * These MACROs can be used for the linear mapping region in the kernel space.
  */
 
-#define KERNEL_PA_TO_VA(pa) ((void *) ((ulong)(pa) + KERNEL_BASE_VA))
-#define KERNEL_VA_TO_PA(va) ((ulong)(va) - KERNEL_BASE_VA)
+#if defined(TESTING) || defined(KERNEL_TEST)
+
+   #define KERNEL_PA_TO_VA(pa) ((void *) ((ulong)(pa) + BASE_VA))
+   #define KERNEL_VA_TO_PA(va) ((ulong)(va) - BASE_VA)
+
+#else
+
+   #define KERNEL_PA_TO_VA(pa) ((void *) ((ulong)(pa) + KERNEL_VADDR - KERNEL_PADDR))
+   #define KERNEL_VA_TO_PA(va) ((ulong)(va) - KERNEL_VADDR + KERNEL_PADDR)
+
+#endif
 
 extern char page_size_buf[PAGE_SIZE] ALIGNED_AT(PAGE_SIZE);
 extern char zero_page[PAGE_SIZE] ALIGNED_AT(PAGE_SIZE);

--- a/include/tilck/kernel/paging_hw.h
+++ b/include/tilck/kernel/paging_hw.h
@@ -17,8 +17,8 @@ static ALWAYS_INLINE pdir_t *get_curr_pdir()
 /*
  * Tilck's entry point is in `_start` where the so-called "original"
  * page directory is set, using the `page_size_buf` as buffer. The original
- * page directory just linearly maps the first 4 MB of the physical memory to
- * KERNEL_BASE_VA. This function returns true if we're still using that page
+ * page directory just linearly maps the first 8 MB of the physical memory to
+ * BASE_VA. This function returns true if we're still using that page
  * directory (-> early_init_paging() has not been called yet).
  */
 static ALWAYS_INLINE bool still_using_orig_pdir(void)

--- a/include/tilck/kernel/user.h
+++ b/include/tilck/kernel/user.h
@@ -5,7 +5,7 @@
 
 static inline bool user_out_of_range(const void *user_ptr, size_t n)
 {
-   return ((ulong)user_ptr + n) > KERNEL_BASE_VA;
+   return ((ulong)user_ptr + n) > BASE_VA;
 }
 
 int copy_from_user(void *dest, const void *user_ptr, size_t n);

--- a/kernel/arch/i386/debug.c
+++ b/kernel/arch/i386/debug.c
@@ -36,7 +36,7 @@ stackwalk32(void **frames,
 
    for (i = 0; i < count; i++) {
 
-      if ((ulong)ebp < KERNEL_BASE_VA)
+      if ((ulong)ebp < BASE_VA)
          break;
 
       if (curr_pdir) {

--- a/kernel/arch/i386/linker_script.ld
+++ b/kernel/arch/i386/linker_script.ld
@@ -8,8 +8,9 @@ SEARCH_DIR("=/tmp/x86-i686--glibc--stable/usr/i686-buildroot-linux-gnu/lib32");
 SEARCH_DIR("=/tmp/x86-i686--glibc--stable/usr/i686-buildroot-linux-gnu/lib");
 
 kernel_paddr        = @KERNEL_PADDR@;
-kernel_text_paddr   = kernel_paddr + 0x1000;
-kernel_va           = @KERNEL_BASE_VA@ + kernel_text_paddr;
+kernel_text_offset  = 0x1000;
+kernel_text_paddr   = kernel_paddr + kernel_text_offset;
+kernel_va           = @KERNEL_VADDR@ + kernel_text_offset;
 
 PHDRS
 {

--- a/kernel/arch/i386/paging.c
+++ b/kernel/arch/i386/paging.c
@@ -349,7 +349,7 @@ ulong get_mapping(pdir_t *pdir, void *vaddrp)
     * This function shall be never called for the linear-mapped zone of the
     * the kernel virtual memory.
     */
-   ASSERT(vaddr < KERNEL_BASE_VA || vaddr >= LINEAR_MAPPING_END);
+   ASSERT(vaddr < BASE_VA || vaddr >= LINEAR_MAPPING_END);
 
    e.raw = pdir->entries[pd_index].raw;
    ASSERT(e.present);
@@ -929,7 +929,7 @@ void *failsafe_map_framebuffer(ulong paddr, ulong size)
    /*
     * Paging has not been initialized yet: probably we're in panic.
     * At this point, the kernel still uses page_size_buf as pdir, with only
-    * the first 4 MB of the physical mapped at KERNEL_BASE_VA.
+    * the first 8 MB of the physical mapped at BASE_VA.
     */
 
    ulong vaddr = FAILSAFE_FB_VADDR;

--- a/kernel/arch/i386/paging_int.h
+++ b/kernel/arch/i386/paging_int.h
@@ -43,7 +43,7 @@
 
 #define PAGE_FAULT_FL_COW (PAGE_FAULT_FL_PRESENT | PAGE_FAULT_FL_RW)
 #define BIG_PAGE_SHIFT                                            22
-#define KERNEL_BASE_PD_IDX        (KERNEL_BASE_VA >> BIG_PAGE_SHIFT)
+#define KERNEL_BASE_PD_IDX               (BASE_VA >> BIG_PAGE_SHIFT)
 
 // A page table entry
 

--- a/kernel/arch/i386/start.S
+++ b/kernel/arch/i386/start.S
@@ -23,7 +23,7 @@
                               MULTIBOOT_MEMORY_INFO |  \
                               MULTIBOOT_VIDEO_MODE)
 
-#define PAGE_DIR_PADDR ((offset page_size_buf) - KERNEL_BASE_VA)
+#define PAGE_DIR_PADDR ((offset page_size_buf) - KERNEL_VADDR + KERNEL_PADDR)
 #define MAKE_BIG_PAGE(paddr) \
    (1 /* present */ | 2 /*RW*/ | (1 << 7) /* bigpage */ | (paddr))
 
@@ -58,7 +58,7 @@ multiboot_entry:
 
    /*
     * Before jump to kernel, we have to setup a basic paging in order to map
-    * the first 4-MB both at 0 and at +KERNEL_BASE_VA. Using 4-MB pages.
+    * the first 8-MB both at 0 and at +(KERNEL_VADDR - KERNEL_PADDR), using 4-MB pages.
     * NOTE: the registers EAX and EBX cannot be used since they contain
     * multiboot information!
     */
@@ -83,9 +83,9 @@ multiboot_entry:
    mov dword ptr [edx + 0], MAKE_BIG_PAGE(0)
    mov dword ptr [edx + 4], MAKE_BIG_PAGE(4 * MB)
 
-   # Map the first 8 MB also at KERNEL_BASE_VA
-   mov dword ptr [edx + (KERNEL_BASE_VA >> 20) + 0], MAKE_BIG_PAGE(0)
-   mov dword ptr [edx + (KERNEL_BASE_VA >> 20) + 4], MAKE_BIG_PAGE(4 * MB)
+   # Map the first 8 MB also at +(KERNEL_VADDR - KERNEL_PADDR)
+   mov dword ptr [edx + ((KERNEL_VADDR - KERNEL_PADDR) >> 20) + 0], MAKE_BIG_PAGE(0)
+   mov dword ptr [edx + ((KERNEL_VADDR - KERNEL_PADDR) >> 20) + 4], MAKE_BIG_PAGE(4 * MB)
 
    # Make sure PAGING is disabled
    mov ecx, cr0
@@ -114,7 +114,7 @@ multiboot_entry:
                   # is removed. We need to continue using high (+3 GB)
                   # virtual addresses. The trick works because this file is
                   # part of the kernel ELF binary where the ORG is set to
-                  # 0xC0100000 (KERNEL_BASE_VA + KERNEL_PADDR).
+                  # 0xC0100000 (KERNEL_VADDR).
 
 .next_step:
    mov esp, offset kernel_initial_stack + ASM_KERNEL_STACK_SZ - 4
@@ -122,6 +122,6 @@ multiboot_entry:
    push ebx    # 2st argument: multiboot information structure
    push eax    # 1nd argument: multiboot magic
    call kmain  # Now call kernel's kmain() which uses
-               # KERNEL_BASE_VA + KERNEL_PADDR as ORG
+               # KERNEL_VADDR as ORG
 
 END_FUNC(_start)

--- a/modules/acpi/osl_mm.c
+++ b/modules/acpi/osl_mm.c
@@ -102,7 +102,7 @@ AcpiOsReadable(
    ulong va_end = va + Length;
    ACPI_FUNCTION_TRACE(__FUNC__);
 
-   if (va < KERNEL_BASE_VA)
+   if (va < BASE_VA)
       return_UINT8(false);
 
    if (va_end <= LINEAR_MAPPING_END)
@@ -130,7 +130,7 @@ AcpiOsWritable(
    int reg_count = get_mem_regions_count();
    ACPI_FUNCTION_TRACE(__FUNC__);
 
-   if (va < KERNEL_BASE_VA)
+   if (va < BASE_VA)
       return_UINT8(false);
 
    for (int i = 0; i < reg_count; i++) {

--- a/other/gdb_scripts/base_utils.py
+++ b/other/gdb_scripts/base_utils.py
@@ -8,7 +8,7 @@ BuildConfig = namedtuple(
    "BuildConfig", [
       "CMAKE_SOURCE_DIR",
       "MAX_HANDLES",
-      "KERNEL_BASE_VA"
+      "BASE_VA",
    ]
 )
 

--- a/other/gdb_scripts/regs_printer.py
+++ b/other/gdb_scripts/regs_printer.py
@@ -25,7 +25,7 @@ class printer_regs:
       eip = r["eip"]
       eip_str = None
 
-      if eip < bu.config.KERNEL_BASE_VA:
+      if eip < bu.config.BASE_VA:
          eip_str = fixhex32(r["eip"])
       else:
          eip_str = gdb.parse_and_eval(

--- a/other/tilck_unstripped-gdb.py
+++ b/other/tilck_unstripped-gdb.py
@@ -14,7 +14,7 @@ bu.set_build_config(
    bu.BuildConfig(
       "@CMAKE_SOURCE_DIR@",
       int("@MAX_HANDLES@"),
-      int("@KERNEL_BASE_VA@", 16),
+      int("@BASE_VA@", 16),
    )
 )
 

--- a/tests/unit/mm_fakes.cpp
+++ b/tests/unit/mm_fakes.cpp
@@ -27,21 +27,21 @@ extern "C" {
 
 extern bool suppress_printk;
 
-void *kernel_va = nullptr;
+void *base_va = nullptr;
 static unordered_map<ulong, ulong> mappings;
 
 void initialize_test_kernel_heap()
 {
    const ulong test_mem_size = 256 * MB;
 
-   if (kernel_va != nullptr) {
-      bzero(kernel_va, test_mem_size);
+   if (base_va != nullptr) {
+      bzero(base_va, test_mem_size);
       mappings.clear();
       return;
    }
 
-   kernel_va = aligned_alloc(MB, test_mem_size);
-   bzero(kernel_va, test_mem_size);
+   base_va = aligned_alloc(MB, test_mem_size);
+   bzero(base_va, test_mem_size);
 
    mem_regions_count = 1;
    mem_regions[0] = (struct mem_region) {


### PR DESCRIPTION
BASE_VA is used for reading the physical memory and KERNEL_VADDR is used for the kernel.

In 64-bit, we want to map the kernel at -2GB to be able to use 32-bit offsets. Hence, a separate vaddr was introduced for achieving this.

To avoid 64-bit specific tricks, this change is
generic and for both 32-bit and 64-bit kernels.