### PR TITLE
/include/tilck/common/compiler.h

### DIFF
--- a/include/tilck/common/compiler.h
+++ b/include/tilck/common/compiler.h
@@ -16,6 +16,6 @@
 
 #else
 
-   #error Compiler not supported
+   #error "Compiler not supported!"
 
 #endif


### PR DESCRIPTION
include/tilck/common/compiler.h #error Compiler not supported
#error "Compiler not supported!" has been changed to .

(I saw it while browsing through the codes and wanted to make a change.)