### PR TITLE
[64-bit] Allow Tilck to be mapped at a non-linear vaddr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,9 @@ set(KERNEL_64BIT_OFFT ON CACHE BOOL
 set(KRN_CLOCK_DRIFT_COMP ON CACHE BOOL
     "Compensate periodically for the clock drift in the system time")
 
+set(KRN32_LIN_VADDR ON CACHE BOOL
+    "Place the 32-bit kernel in the default linear mapping")
+
 # Kernel options (disabled by default)
 
 set(KRN_PAGE_FAULT_PRINTK OFF CACHE BOOL
@@ -542,9 +545,18 @@ if (${ARCH} STREQUAL "i386")
    set(ARCH_BITS        32)
 
    # Fundamental kernel MM constants
-   set(KERNEL_BASE_VA     0xC0000000)  # Better not touch!
+   set(BASE_VA            0xC0000000)  # Better not touch!
    set(KERNEL_PADDR       0x00100000)  # Better not touch!
-   set(LINEAR_MAPPING_MB         896)  # Better not touch!
+
+   if (KRN32_LIN_VADDR)
+      set(LINEAR_MAPPING_MB         896)  # Cannot be > 896 MB because of HiMem
+      set(KERNEL_BASE_VA     ${BASE_VA})
+      set(KERNEL_VADDR       0xC0100000)  # BASE_VA + KERNEL_PADDR
+   else()
+      set(LINEAR_MAPPING_MB         880)  # Make room for the kernel and extra
+      set(KERNEL_BASE_VA     0xF7000000)  # LINEAR_MAPPING_END
+      set(KERNEL_VADDR       0xF7100000)  # LINEAR_MAPPING_END + KERNEL_PADDR
+   endif()
 
 elseif(${ARCH} STREQUAL "x86_64")
 
@@ -558,9 +570,11 @@ elseif(${ARCH} STREQUAL "x86_64")
    set(ARCH_BITS        64)
 
    # Fundamental kernel MM constants
-   set(KERNEL_BASE_VA      0x100000000000)  # +16 TB
-   set(KERNEL_PADDR            0x00100000)  # Better not touch!
-   set(LINEAR_MAPPING_MB             4096)  # Might be updated.
+   set(BASE_VA                0x100000000000)  # +16 TB
+   set(KERNEL_PADDR               0x00100000)  # Better not touch (for now)
+   set(LINEAR_MAPPING_MB                4096)  # Might be updated.
+   set(KERNEL_BASE_VA     0xFFFFFFFF80000000)
+   set(KERNEL_VADDR       0xFFFFFFFF80100000)  # -2 GB + 1 MB
 
 else()
 

--- a/boot/common/main_common_logic.c
+++ b/boot/common/main_common_logic.c
@@ -101,7 +101,6 @@ check_elf_kernel(void)
       if (phdr->p_type != PT_LOAD)
          continue;
 
-      CHECK(phdr->p_vaddr >= KERNEL_BASE_VA);
       CHECK(phdr->p_paddr >= KERNEL_PADDR);
    }
 

--- a/boot/common/simple_elf_loader.c
+++ b/boot/common/simple_elf_loader.c
@@ -47,7 +47,7 @@ void *simple_elf_loader(void *elf)
                    phdr->p_vaddr + phdr->p_filesz))
       {
          /*
-          * If e_entry is a vaddr (address >= KERNEL_BASE_VA), we need to
+          * If e_entry is a vaddr (address >= KERNEL_VADDR), we need to
           * calculate its paddr because here paging is OFF. Therefore,
           * compute its offset from the beginning of the segment and add it
           * to the paddr of the segment.

--- a/boot/efi/ramdisk.c
+++ b/boot/efi/ramdisk.c
@@ -133,7 +133,7 @@ LoadRamdisk_AllocMem(struct load_ramdisk_ctx *ctx)
 
    /*
     * Because Tilck is 32-bit and it maps the first LINEAR_MAPPING_SIZE of
-    * physical memory at KERNEL_BASE_VA, we really cannot accept ANY address
+    * physical memory at BASE_VA, we really cannot accept ANY address
     * in the 64-bit space, because from Tilck we won't be able to read from
     * there. The address of the ramdisk we actually be at most:
     *

--- a/config/config_global.h
+++ b/config/config_global.h
@@ -27,8 +27,10 @@
 
 #define KERNEL_STACK_PAGES     @KERNEL_STACK_PAGES@
 #define KERNEL_PADDR           @KERNEL_PADDR@
-#define KERNEL_BASE_VA         @KERNEL_BASE_VA@
+#define BASE_VA                @BASE_VA@
 #define LINEAR_MAPPING_MB      @LINEAR_MAPPING_MB@UL
+#define KERNEL_BASE_VA         @KERNEL_BASE_VA@
+#define KERNEL_VADDR           @KERNEL_VADDR@
 
 #define ARCH_BITS              @ARCH_BITS@
 
@@ -61,19 +63,19 @@
 
 #if defined(TESTING) || defined(KERNEL_TEST)
 
-   extern void *kernel_va;
+   extern void *base_va;
 
    /* For the unit tests, we need to override the following defines */
-   #undef KERNEL_BASE_VA
+   #undef BASE_VA
    #undef LINEAR_MAPPING_MB
 
-   #define KERNEL_BASE_VA             ((ulong)kernel_va)
+   #define BASE_VA                    ((ulong)base_va)
    #define LINEAR_MAPPING_MB          (128u)
 
 #endif
 
 #define LINEAR_MAPPING_SIZE        (LINEAR_MAPPING_MB << 20)
-#define LINEAR_MAPPING_END         (KERNEL_BASE_VA + LINEAR_MAPPING_SIZE)
+#define LINEAR_MAPPING_END         (BASE_VA + LINEAR_MAPPING_SIZE)
 
 /* Constants that have no reason to be changed */
 #define FREE_MEM_POISON_VAL    0xFAABCAFE

--- a/config/config_kernel.h
+++ b/config/config_kernel.h
@@ -19,6 +19,7 @@
 #cmakedefine01 KERNEL_UBSAN
 #cmakedefine01 KERNEL_64BIT_OFFT
 #cmakedefine01 KRN_CLOCK_DRIFT_COMP
+#cmakedefine01 KRN32_LIN_VADDR
 
 /*
  * --------------------------------------------------------------------------

--- a/config/config_mm.h
+++ b/config/config_mm.h
@@ -33,10 +33,12 @@
  * variable.
  */
 
+#define HI_VMEM_START    (BASE_VA + 896 * MB)
+#define HI_VMEM_SIZE             (128ul * MB)
 
-#define USER_VDSO_VADDR  (LINEAR_MAPPING_END)
+#define USER_VDSO_VADDR       (HI_VMEM_START)
 
-#define USERMODE_VADDR_END   (KERNEL_BASE_VA) /* biggest user vaddr + 1 */
+#define USERMODE_VADDR_END          (BASE_VA) /* biggest user vaddr + 1 */
 #define MAX_BRK                  (0x40000000) /* +1 GB (virtual memory) */
 #define USER_MMAP_BEGIN               MAX_BRK /* +1 GB (virtual memory) */
 #define USER_MMAP_MIN_SZ            (16 * MB)

--- a/config/mod_fb.h
+++ b/config/mod_fb.h
@@ -35,4 +35,4 @@
 
 
 #define FBCON_OPT_FUNCS_MIN_FREE_HEAP                        (16 * MB)
-#define FAILSAFE_FB_VADDR          (KERNEL_BASE_VA + (1024 - 64) * MB)
+#define FAILSAFE_FB_VADDR                 (BASE_VA + (1024 - 64) * MB)

--- a/include/tilck/kernel/paging.h
+++ b/include/tilck/kernel/paging.h
@@ -29,10 +29,23 @@
 #define PAGING_FL_RWUS               (PAGING_FL_RW | PAGING_FL_US)
 
 /*
- * These MACROs can be used for the linear mapping region in the kernel space.
+ * These MACROs convert addresses to/from the linear mapping at BASE_VA to the
+ * physical address space.
  */
+#define PA_TO_LIN_VA(pa) ((void *) ((ulong)(pa) + BASE_VA))
+#define LIN_VA_TO_PA(va) ((ulong)(va) - BASE_VA)
 
-#define KERNEL_PA_TO_VA(pa) ((void *) ((ulong)(pa) + KERNEL_BASE_VA))
+/*
+ * These MACROs convert addresses to/from the kernel base virtual mapping to
+ * the physical address space. When KRN32_LIN_VADDR is enabled, KERNEL_BASE_VA
+ * is the same as BASE_VA, so the following macros are identical to the ones
+ * above. When KRN32_LIN_VADDR is disabled, KERNEL_BASE_VA will be != BASE_VA.
+ *
+ * In the 64-bit case, the kernel will always be mapped at a non linear, as if
+ * KRN32_LIN_VADDR were always disabled. Indeed, its value is ignored in the 64
+ * bit case.
+ */
+#define PA_TO_KERNEL_VA(pa) ((void *) ((ulong)(pa) + KERNEL_BASE_VA))
 #define KERNEL_VA_TO_PA(va) ((ulong)(va) - KERNEL_BASE_VA)
 
 extern char page_size_buf[PAGE_SIZE] ALIGNED_AT(PAGE_SIZE);

--- a/include/tilck/kernel/paging_hw.h
+++ b/include/tilck/kernel/paging_hw.h
@@ -6,25 +6,30 @@
 
 static ALWAYS_INLINE void set_curr_pdir(pdir_t *pdir)
 {
-   __set_curr_pdir(KERNEL_VA_TO_PA(pdir));
+   __set_curr_pdir(LIN_VA_TO_PA(pdir));
 }
 
 static ALWAYS_INLINE pdir_t *get_curr_pdir()
 {
-   return (pdir_t *)KERNEL_PA_TO_VA(__get_curr_pdir());
+   return PA_TO_LIN_VA(__get_curr_pdir());
 }
 
 /*
  * Tilck's entry point is in `_start` where the so-called "original"
  * page directory is set, using the `page_size_buf` as buffer. The original
- * page directory just linearly maps the first 4 MB of the physical memory to
- * KERNEL_BASE_VA. This function returns true if we're still using that page
+ * page directory just linearly maps the first 8 MB of the physical memory to
+ * BASE_VA. This function returns true if we're still using that page
  * directory (-> early_init_paging() has not been called yet).
  */
 static ALWAYS_INLINE bool still_using_orig_pdir(void)
 {
 #ifndef UNIT_TEST_ENVIRONMENT
-   return get_curr_pdir() == (void *)page_size_buf;
+   /*
+    * Use the lower-level __get_curr_pdir() function and compare the pdirs using
+    * their physical address, in order to handle the case where KRN32_LIN_VADDR
+    * is disabled.
+    */
+   return __get_curr_pdir() == KERNEL_VA_TO_PA(page_size_buf);
 #else
    return false;
 #endif

--- a/include/tilck/kernel/user.h
+++ b/include/tilck/kernel/user.h
@@ -5,7 +5,7 @@
 
 static inline bool user_out_of_range(const void *user_ptr, size_t n)
 {
-   return ((ulong)user_ptr + n) > KERNEL_BASE_VA;
+   return ((ulong)user_ptr + n) > BASE_VA;
 }
 
 int copy_from_user(void *dest, const void *user_ptr, size_t n);

--- a/kernel/arch/i386/debug.c
+++ b/kernel/arch/i386/debug.c
@@ -36,7 +36,7 @@ stackwalk32(void **frames,
 
    for (i = 0; i < count; i++) {
 
-      if ((ulong)ebp < KERNEL_BASE_VA)
+      if ((ulong)ebp < BASE_VA)
          break;
 
       if (curr_pdir) {

--- a/kernel/arch/i386/linker_script.ld
+++ b/kernel/arch/i386/linker_script.ld
@@ -8,8 +8,9 @@ SEARCH_DIR("=/tmp/x86-i686--glibc--stable/usr/i686-buildroot-linux-gnu/lib32");
 SEARCH_DIR("=/tmp/x86-i686--glibc--stable/usr/i686-buildroot-linux-gnu/lib");
 
 kernel_paddr        = @KERNEL_PADDR@;
-kernel_text_paddr   = kernel_paddr + 0x1000;
-kernel_va           = @KERNEL_BASE_VA@ + kernel_text_paddr;
+kernel_text_offset  = 0x1000;
+kernel_text_paddr   = kernel_paddr + kernel_text_offset;
+kernel_va           = @KERNEL_VADDR@ + kernel_text_offset;
 
 PHDRS
 {

--- a/kernel/arch/i386/paging_int.h
+++ b/kernel/arch/i386/paging_int.h
@@ -43,7 +43,7 @@
 
 #define PAGE_FAULT_FL_COW (PAGE_FAULT_FL_PRESENT | PAGE_FAULT_FL_RW)
 #define BIG_PAGE_SHIFT                                            22
-#define KERNEL_BASE_PD_IDX        (KERNEL_BASE_VA >> BIG_PAGE_SHIFT)
+#define BASE_VADDR_PD_IDX                (BASE_VA >> BIG_PAGE_SHIFT)
 
 // A page table entry
 

--- a/kernel/arch/i386/start.S
+++ b/kernel/arch/i386/start.S
@@ -58,7 +58,7 @@ multiboot_entry:
 
    /*
     * Before jump to kernel, we have to setup a basic paging in order to map
-    * the first 4-MB both at 0 and at +KERNEL_BASE_VA. Using 4-MB pages.
+    * the first 4-MB both at 0 and at +BASE_VA. Using 4-MB pages.
     * NOTE: the registers EAX and EBX cannot be used since they contain
     * multiboot information!
     */
@@ -80,12 +80,25 @@ multiboot_entry:
 
    # Identity map the first 8 MB: that's necessary in order to avoid crashing
    # due to a page fault once we execute: mov cr3, edx, below.
+   #
+   # TODO: replace the 8 * MB fixed mapping with a well-defined constant
+   # and use the GAS macros to implement a loop to map an abitrary-sized
+   # mapping (aligned at BIG_PAGE_SIZE, of course).
+   #
    mov dword ptr [edx + 0], MAKE_BIG_PAGE(0)
    mov dword ptr [edx + 4], MAKE_BIG_PAGE(4 * MB)
 
-   # Map the first 8 MB also at KERNEL_BASE_VA
-   mov dword ptr [edx + (KERNEL_BASE_VA >> 20) + 0], MAKE_BIG_PAGE(0)
-   mov dword ptr [edx + (KERNEL_BASE_VA >> 20) + 4], MAKE_BIG_PAGE(4 * MB)
+   # Map the first 8 MB also at BASE_VA
+   mov dword ptr [edx + (BASE_VA >> 20) + 0], MAKE_BIG_PAGE(0)
+   mov dword ptr [edx + (BASE_VA >> 20) + 4], MAKE_BIG_PAGE(4 * MB)
+
+#if !KRN32_LIN_VADDR
+
+   # Map 8 MB starting at KERNEL_PADDR to KERNEL_VADDR
+   mov dword ptr [edx + (KERNEL_BASE_VA >> 20) +  0], MAKE_BIG_PAGE(0)
+   mov dword ptr [edx + (KERNEL_BASE_VA >> 20) +  4], MAKE_BIG_PAGE(4  * MB)
+
+#endif
 
    # Make sure PAGING is disabled
    mov ecx, cr0
@@ -114,7 +127,7 @@ multiboot_entry:
                   # is removed. We need to continue using high (+3 GB)
                   # virtual addresses. The trick works because this file is
                   # part of the kernel ELF binary where the ORG is set to
-                  # 0xC0100000 (KERNEL_BASE_VA + KERNEL_PADDR).
+                  # 0xC0100000 (KERNEL_VADDR).
 
 .next_step:
    mov esp, offset kernel_initial_stack + ASM_KERNEL_STACK_SZ - 4
@@ -122,6 +135,6 @@ multiboot_entry:
    push ebx    # 2st argument: multiboot information structure
    push eax    # 1nd argument: multiboot magic
    call kmain  # Now call kernel's kmain() which uses
-               # KERNEL_BASE_VA + KERNEL_PADDR as ORG
+               # KERNEL_VADDR as ORG
 
 END_FUNC(_start)

--- a/kernel/elf.c
+++ b/kernel/elf.c
@@ -70,7 +70,7 @@ load_segment_by_copy(fs_handle *elf_h,
          if (!(p = kzmalloc(PAGE_SIZE)))
             return -ENOMEM;
 
-         if ((rc = map_page(pdir, vaddr, KERNEL_VA_TO_PA(p), PAGING_FL_RWUS))) {
+         if ((rc = map_page(pdir, vaddr, LIN_VA_TO_PA(p), PAGING_FL_RWUS))) {
             kfree2(p, PAGE_SIZE);
             return (int)rc;
          }
@@ -78,7 +78,7 @@ load_segment_by_copy(fs_handle *elf_h,
       } else {
 
          /* Get user's vaddr as a kernel vaddr */
-         p = KERNEL_PA_TO_VA(get_mapping(pdir, vaddr));
+         p = PA_TO_LIN_VA(get_mapping(pdir, vaddr));
       }
 
       if (filesz_rem) {
@@ -301,7 +301,7 @@ alloc_and_map_stack_page(pdir_t *pdir, void *stack_top, u32 i)
 
    rc = map_page(pdir,
                  (void *)stack_top + (i << PAGE_SHIFT),
-                 KERNEL_VA_TO_PA(p),
+                 LIN_VA_TO_PA(p),
                  PAGING_FL_RW | PAGING_FL_US);
 
    return rc;
@@ -482,7 +482,7 @@ out:
 
 void get_symtab_and_strtab(Elf_Shdr **symtab, Elf_Shdr **strtab)
 {
-   Elf_Ehdr *h = (Elf_Ehdr*)(KERNEL_PA_TO_VA(KERNEL_PADDR));
+   Elf_Ehdr *h = (Elf_Ehdr*)KERNEL_VADDR;
    *symtab = NULL;
    *strtab = NULL;
 
@@ -612,7 +612,7 @@ find_sym_at_addr_safe(ulong vaddr, long *offset, u32 *sym_size)
 
 static Elf_Shdr *kernel_elf_get_section(const char *section_name)
 {
-   Elf_Ehdr *h = (Elf_Ehdr*)(KERNEL_PA_TO_VA(KERNEL_PADDR));
+   Elf_Ehdr *h = (Elf_Ehdr*)KERNEL_VADDR;
    Elf_Shdr *sections = (Elf_Shdr *)((void *)h + h->e_shoff);
    Elf_Shdr *section_header_strtab = sections + h->e_shstrndx;
 

--- a/kernel/fs/fat32_mm.c
+++ b/kernel/fs/fat32_mm.c
@@ -146,7 +146,7 @@ int fat_mmap(struct user_mapping *um, pdir_t *pdir, int flags)
 
          mapped_cnt = map_pages(pdir,
                                 (void *)vaddr,
-                                KERNEL_VA_TO_PA(data),
+                                LIN_VA_TO_PA(data),
                                 pg_count,
                                 PAGING_FL_US | PAGING_FL_SHARED);
 

--- a/kernel/fs/ramfs/mmap.c.h
+++ b/kernel/fs/ramfs/mmap.c.h
@@ -48,7 +48,7 @@ ramfs_mmap(struct user_mapping *um, pdir_t *pdir, int flags)
 
       rc = map_page(pdir,
                     (void *)vaddr,
-                    KERNEL_VA_TO_PA(b->vaddr),
+                    LIN_VA_TO_PA(b->vaddr),
                     pg_flags);
 
       if (rc) {
@@ -117,7 +117,7 @@ ramfs_handle_fault_int(struct process *pi,
 
    rc = map_page(pi->pdir,
                  (void *)(vaddr & PAGE_MASK),
-                 KERNEL_VA_TO_PA(rw ? block->vaddr : &zero_page),
+                 rw ? LIN_VA_TO_PA(block->vaddr) : KERNEL_VA_TO_PA(&zero_page),
                  PAGING_FL_US | PAGING_FL_RW | PAGING_FL_SHARED);
 
    if (rc)

--- a/kernel/mm/process_mm.c
+++ b/kernel/mm/process_mm.c
@@ -54,7 +54,7 @@ static inline void sys_brk_internal(struct process *pi, void *new_brk)
       if (!kernel_vaddr)
          break; /* we've allocated as much as possible */
 
-      const ulong paddr = KERNEL_VA_TO_PA(kernel_vaddr);
+      const ulong paddr = LIN_VA_TO_PA(kernel_vaddr);
 
       if (map_page(pi->pdir, vaddr, paddr, PAGING_FL_RWUS) != 0) {
          kfree2(kernel_vaddr, PAGE_SIZE);

--- a/kernel/mm/process_mm_base.c
+++ b/kernel/mm/process_mm_base.c
@@ -246,7 +246,7 @@ bool user_valloc_and_map_slow(ulong user_vaddr, size_t page_count)
          return false;
       }
 
-      pa = KERNEL_VA_TO_PA(kernel_vaddr);
+      pa = LIN_VA_TO_PA(kernel_vaddr);
 
       if (map_page(pdir, (void *)va, pa, PAGING_FL_RWUS) != 0) {
          kfree2(kernel_vaddr, PAGE_SIZE);
@@ -274,7 +274,7 @@ bool user_valloc_and_map(ulong user_vaddr, size_t page_count)
 
    count = map_pages(pdir,
                      (void *)user_vaddr,
-                     KERNEL_VA_TO_PA(kernel_vaddr),
+                     LIN_VA_TO_PA(kernel_vaddr),
                      page_count,
                      PAGING_FL_US | PAGING_FL_RW);
 

--- a/kernel/mm/system_mmap.c
+++ b/kernel/mm/system_mmap.c
@@ -107,7 +107,7 @@ int system_mmap_get_ramdisk(int ramdisk_index, void **va, size_t *size)
          if (rd_count == ramdisk_index) {
 
             if (va)
-               *va = KERNEL_PA_TO_VA((ulong)m->addr);
+               *va = PA_TO_LIN_VA((ulong)m->addr);
 
             if (size)
                *size = (size_t)m->len;
@@ -420,7 +420,7 @@ STATIC void fix_mem_regions(void)
 
 STATIC void add_kernel_phdrs_to_mmap(void)
 {
-   Elf_Ehdr *h = (Elf_Ehdr*)(KERNEL_PA_TO_VA(KERNEL_PADDR));
+   Elf_Ehdr *h = (Elf_Ehdr*)KERNEL_VADDR;
    Elf_Phdr *phdrs = (void *)h + h->e_phoff;
 
    for (int i = 0; i < h->e_phnum; i++) {
@@ -550,8 +550,8 @@ linear_map_mem_region(struct mem_region *r, ulong *vbegin, ulong *vend)
    const bool big_pages = !(r->extra & MEM_REG_EXTRA_RAMDISK);
    const size_t page_count = (pend - pbegin) >> PAGE_SHIFT;
 
-   *vbegin = (ulong)KERNEL_PA_TO_VA(pbegin);
-   *vend = (ulong)KERNEL_PA_TO_VA(pend);
+   *vbegin = (ulong)PA_TO_LIN_VA(pbegin);
+   *vend = (ulong)PA_TO_LIN_VA(pend);
 
    size_t count =
       map_pages(get_kernel_pdir(),
@@ -574,7 +574,7 @@ linear_map_mem_region(struct mem_region *r, ulong *vbegin, ulong *vend)
 
 bool system_mmap_check_for_extra_ramdisk_region(void *rd)
 {
-   int ri = system_mmap_get_region_of(KERNEL_VA_TO_PA(rd));
+   int ri = system_mmap_get_region_of(LIN_VA_TO_PA(rd));
    struct mem_region *r;
    VERIFY(ri >= 0);
 

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -40,7 +40,7 @@ static void *alloc_kernel_isolated_stack(struct process *pi)
    if (!direct_va)
       return NULL;
 
-   direct_pa = KERNEL_VA_TO_PA(direct_va);
+   direct_pa = LIN_VA_TO_PA(direct_va);
    block_vaddr = hi_vmem_reserve(ISOLATED_STACK_HI_VMEM_SPACE);
 
    if (!block_vaddr) {
@@ -71,7 +71,7 @@ free_kernel_isolated_stack(struct process *pi, void *vaddr_in_block)
 {
    void *block_vaddr = (void *)((ulong)vaddr_in_block - PAGE_SIZE);
    ulong direct_pa = get_mapping(get_kernel_pdir(), vaddr_in_block);
-   void *direct_va = KERNEL_PA_TO_VA(direct_pa);
+   void *direct_va = PA_TO_LIN_VA(direct_pa);
 
    unmap_pages(get_kernel_pdir(), vaddr_in_block, KERNEL_STACK_PAGES, false);
    hi_vmem_release(block_vaddr, ISOLATED_STACK_HI_VMEM_SPACE);

--- a/kernel/uefi.c
+++ b/kernel/uefi.c
@@ -25,7 +25,7 @@ void uefi_set_rt_pointer(ulong addr)
 
 void hw_read_clock_uefi(struct datetime *out)
 {
-   EFI_RUNTIME_SERVICES *RT = KERNEL_PA_TO_VA(uefi_rt_addr);
+   EFI_RUNTIME_SERVICES *RT = PA_TO_LIN_VA(uefi_rt_addr);
    EFI_STATUS status;
    EFI_TIME t;
 
@@ -130,7 +130,7 @@ void setup_uefi_runtime_services(void)
             : EfiRuntimeServicesData;
 
       desc.PhysicalStart = (ulong)ma.addr;
-      desc.VirtualStart = (ulong)KERNEL_PA_TO_VA(ma.addr);
+      desc.VirtualStart = (ulong)PA_TO_LIN_VA(ma.addr);
       desc.NumberOfPages = ma.len >> PAGE_SHIFT;
       desc.Attribute = EFI_MEMORY_RUNTIME;
 
@@ -146,7 +146,7 @@ void setup_uefi_runtime_services(void)
    if (status != EFI_SUCCESS)
       panic("Failed to set the UEFI virtual map");
 
-   RT = KERNEL_PA_TO_VA(RT);
+   RT = PA_TO_LIN_VA(RT);
 
    /* Pollute the virtual map object, to make sure it's not used anymore */
    memset(virt_map, 0xAA, num_entries * sizeof(EFI_MEMORY_DESCRIPTOR));

--- a/modules/acpi/osl_mm.c
+++ b/modules/acpi/osl_mm.c
@@ -28,7 +28,7 @@ AcpiOsMapMemory(
    ACPI_FUNCTION_TRACE(__FUNC__);
 
    if (paddr + Length <= LINEAR_MAPPING_SIZE)
-      return_PTR(KERNEL_PA_TO_VA(Where));
+      return_PTR(PA_TO_LIN_VA(Where));
 
    // printk("ACPI: mmap 0x%08llx (len: %zu -> %zuK)\n",
    //        paddr, RawLength, Length/KB);
@@ -102,7 +102,7 @@ AcpiOsReadable(
    ulong va_end = va + Length;
    ACPI_FUNCTION_TRACE(__FUNC__);
 
-   if (va < KERNEL_BASE_VA)
+   if (va < BASE_VA)
       return_UINT8(false);
 
    if (va_end <= LINEAR_MAPPING_END)
@@ -130,7 +130,7 @@ AcpiOsWritable(
    int reg_count = get_mem_regions_count();
    ACPI_FUNCTION_TRACE(__FUNC__);
 
-   if (va < KERNEL_BASE_VA)
+   if (va < BASE_VA)
       return_UINT8(false);
 
    for (int i = 0; i < reg_count; i++) {
@@ -192,7 +192,7 @@ AcpiOsReadMemory(
       NOT_IMPLEMENTED();
 
    } else {
-      va = KERNEL_PA_TO_VA(Address);
+      va = PA_TO_LIN_VA(Address);
    }
 
    switch (Width) {
@@ -230,7 +230,7 @@ AcpiOsWriteMemory(
       NOT_IMPLEMENTED();
 
    } else {
-      va = KERNEL_PA_TO_VA(Address);
+      va = PA_TO_LIN_VA(Address);
    }
 
    switch (Width) {

--- a/modules/console/generic_x86/textmode_video.c
+++ b/modules/console/generic_x86/textmode_video.c
@@ -8,7 +8,7 @@
 #include <tilck/kernel/hal.h>
 #include <tilck/kernel/term.h>
 
-#define VIDEO_ADDR ((u16 *) KERNEL_PA_TO_VA(0xB8000))
+#define VIDEO_ADDR ((u16 *) PA_TO_LIN_VA(0xB8000))
 #define VIDEO_COLS 80
 #define VIDEO_ROWS 25
 
@@ -124,7 +124,7 @@ void init_textmode_console(void)
    if (pdir != NULL && !is_mapped(pdir, VIDEO_ADDR)) {
       int rc = map_page(pdir,
                         VIDEO_ADDR,
-                        KERNEL_VA_TO_PA(VIDEO_ADDR),
+                        LIN_VA_TO_PA(VIDEO_ADDR),
                         PAGING_FL_RW);
 
       if (rc < 0)

--- a/modules/sb16/generic_x86/sb16.c
+++ b/modules/sb16/generic_x86/sb16.c
@@ -56,7 +56,7 @@ sb16_alloc_buf(void)
    if (!sb16_info.buf)
       return -ENOMEM;
 
-   sb16_info.buf_paddr = KERNEL_VA_TO_PA(sb16_info.buf);
+   sb16_info.buf_paddr = LIN_VA_TO_PA(sb16_info.buf);
 
    /* The buffer must be aligned at 64-KB boundary */
    ASSERT((sb16_info.buf_paddr & (64 * KB - 1)) == 0);

--- a/modules/sysfs/fileops.c.h
+++ b/modules/sysfs/fileops.c.h
@@ -380,7 +380,7 @@ int sysfs_mmap(struct user_mapping *um, pdir_t *pdir, int flags)
 
    mapped_cnt = map_pages(pdir,
                           (void *)vaddr,
-                          KERNEL_VA_TO_PA(data) + um->off,
+                          LIN_VA_TO_PA(data) + um->off,
                           pg_count,
                           PAGING_FL_US | PAGING_FL_SHARED);
 

--- a/other/gdb_scripts/base_utils.py
+++ b/other/gdb_scripts/base_utils.py
@@ -8,7 +8,7 @@ BuildConfig = namedtuple(
    "BuildConfig", [
       "CMAKE_SOURCE_DIR",
       "MAX_HANDLES",
-      "KERNEL_BASE_VA"
+      "BASE_VA"
    ]
 )
 

--- a/other/gdb_scripts/regs_printer.py
+++ b/other/gdb_scripts/regs_printer.py
@@ -25,7 +25,7 @@ class printer_regs:
       eip = r["eip"]
       eip_str = None
 
-      if eip < bu.config.KERNEL_BASE_VA:
+      if eip < bu.config.BASE_VA:
          eip_str = fixhex32(r["eip"])
       else:
          eip_str = gdb.parse_and_eval(

--- a/other/tilck_unstripped-gdb.py
+++ b/other/tilck_unstripped-gdb.py
@@ -14,7 +14,7 @@ bu.set_build_config(
    bu.BuildConfig(
       "@CMAKE_SOURCE_DIR@",
       int("@MAX_HANDLES@"),
-      int("@KERNEL_BASE_VA@", 16),
+      int("@BASE_VA@", 16),
    )
 )
 

--- a/tests/unit/mm_fakes.cpp
+++ b/tests/unit/mm_fakes.cpp
@@ -27,21 +27,21 @@ extern "C" {
 
 extern bool suppress_printk;
 
-void *kernel_va = nullptr;
+void *base_va = nullptr;
 static unordered_map<ulong, ulong> mappings;
 
 void initialize_test_kernel_heap()
 {
    const ulong test_mem_size = 256 * MB;
 
-   if (kernel_va != nullptr) {
-      bzero(kernel_va, test_mem_size);
+   if (base_va != nullptr) {
+      bzero(base_va, test_mem_size);
       mappings.clear();
       return;
    }
 
-   kernel_va = aligned_alloc(MB, test_mem_size);
-   bzero(kernel_va, test_mem_size);
+   base_va = aligned_alloc(MB, test_mem_size);
+   bzero(base_va, test_mem_size);
 
    mem_regions_count = 1;
    mem_regions[0] = (struct mem_region) {


### PR DESCRIPTION
This is the part of two of commit 29ee48c7f3. Here we completely decouple the default linear mapping of the physical address space from the kernel's vaddr of text, data & bss. By default, the 32-bit Tilck kernel will continue to be mapped at BASE_VA + KERNEL_PADDR, using the general-purpose linear mapping, but when the KRN32_LIN_VADDR option is enabled, the kernel itself will be mapped at a much higher address, linear the LINEAR_MAPPING_END.

The reason is the same as 29ee48c7f3: the 64-bit kernel will need to be mapped well outside of the 4 GB limit in order to support more physical memory in the linear mapping. But, doing that while keeping the linear mapping will be extremely inefficient because all the major compilers will refuse to compile an ELF binary placed at such a high vaddr without using -mcmodel=large. And the problem with that is that -mcmodel=large uses inefficient instructions to access global variables and call functions because it doesn't assume that data and text are within 2 GB of any point. It assumes that each variable or function can be *anywhere* in the 64-bit virtual address space, while that is not true. In theory, it's totally possible to patch the compiler and make it use a small memory model at a high address, but why bothering with that? The mainstream solution is simply to place the kernel somewhere within [-2 GB, 0). This allows both using the smaller (and more efficient) memory model and to leave all the virtual space we want for user programs.