### PR TITLE
[kernel]: Use a switch statement in kopt_handle_bool()

### DIFF
--- a/kernel/cmdline.c
+++ b/kernel/cmdline.c
@@ -43,14 +43,19 @@ struct kopt {
 
 static void kopt_handle_bool(bool *var, const char *arg)
 {
-   if (*arg == '-')
-      *var = true;
-   else if (!strcmp(arg, "0"))
+   switch (*arg) {
+   case '0':
       *var = false;
-   else if (!strcmp(arg, "1"))
+      break;
+
+   case '-':
+   case '1':
       *var = true;
-   else
+      break;
+
+   default:
       NOT_REACHED();
+   }
 }
 
 static void kopt_handle_long(long *var, const char *arg)


### PR DESCRIPTION
Hello,
`kopt_handle_bool(...)` function uses `strcmp(...)` to compare a single character, but as it's just a single character and not a stream of characters, we shall not need to use the `strcmp(...)` function.