### PR TITLE
[64-bit] Introduce a fake implementation for fault_resumable_call()

### DIFF
--- a/kernel/arch/x86_64/debug.c
+++ b/kernel/arch/x86_64/debug.c
@@ -16,10 +16,10 @@
 
 void dump_stacktrace(void *ebp, pdir_t *pdir)
 {
-   NOT_IMPLEMENTED();
+   // TODO: implement dump_stacktrace for x86-64
 }
 
 void dump_regs(regs_t *r)
 {
-   NOT_IMPLEMENTED();
+   // TODO: implement dump_regs for x86-64
 }

--- a/kernel/arch/x86_64/fault_resumable.S
+++ b/kernel/arch/x86_64/fault_resumable.S
@@ -14,13 +14,22 @@
 .global fault_resumable_call
 
 FUNC(fault_resumable_call):
-
-   # TODO: implement this
+                                   // our 1st arg (mask) -> ignored
+   mov     rax, rsi                // our 2nd arg (func pointer) -> RAX
+                                   // our 3rd arg (nargs) -> ignored
+   mov     rdi, rcx                // our 4rd arg -> 1st arg for func (RDI)
+   mov     rsi, r8                 // our 5th arg -> 2nd arg for func (RSI)
+   mov     rdx, r9                 // our 6th arg -> 3rd arg for func (RDX)
+   mov     rcx, QWORD PTR [rsp+16] // our 7th arg -> 4th arg of func (RCX)
+   mov     r8, QWORD PTR [rsp+24]  // our 8th arg -> 5th arg of func (R8)
+   mov     r9, QWORD PTR [rsp+32]  // our 9th arg -> 6th arg of func (R9)
+   call    rax
+   xor     rax, rax // simulate no faults, return 0
    ret
 
 .asm_fault_resumable_call_resume:
 
-   # TODO: implement this
+   //TODO: implement this
    ret
 
 END_FUNC(fault_resumable_call)

--- a/kernel/arch/x86_64/paging64.c
+++ b/kernel/arch/x86_64/paging64.c
@@ -53,7 +53,10 @@ void handle_page_fault_int(regs_t *r)
 
 bool is_mapped(pdir_t *pdir, void *vaddrp)
 {
-   NOT_IMPLEMENTED();
+   /*
+    * TODO: implement is_mapped() for x86-64.
+    */
+   return true;
 }
 
 bool is_rw_mapped(pdir_t *pdir, void *vaddrp)


### PR DESCRIPTION
This allows the x86-64 Tilck to:

   - initialize the textmode_video term
   - initialize term
   - initialize the console
   - run panic() and display a message correctly