### PR TITLE
Replicate printk() messages in the trace event buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,9 @@ set(KRN32_LIN_VADDR ON CACHE BOOL
 
 set(USERAPPS_busybox ON CACHE BOOL "Include BUSYBOX (recommended)")
 
+set(TRACE_PRINTK_ENABLED_ON_BOOT ON CACHE BOOL
+    "Make trace_printk() to be always enabled since boot time")
+
 # Kernel options (disabled by default)
 
 set(KRN_PAGE_FAULT_PRINTK OFF CACHE BOOL
@@ -473,6 +476,9 @@ list(
    KRN_NO_SYS_WARN
    KERNEL_64BIT_OFFT
    KRN_CLOCK_DRIFT_COMP
+   KRN32_LIN_VADDR
+   USERAPPS_busybox
+   TRACE_PRINTK_ENABLED_ON_BOOT
 
    # Boolean options DISABLED by default
    KERNEL_UBSAN

--- a/config/mod_tracing.h
+++ b/config/mod_tracing.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #cmakedefine01    MOD_tracing
+#cmakedefine01    TRACE_PRINTK_ENABLED_ON_BOOT
 
 #ifdef KERNEL_TEST
    #define MOD_tracing_actual 1

--- a/include/tilck/mods/tracing.h
+++ b/include/tilck/mods/tracing.h
@@ -150,6 +150,9 @@ struct syscall_info {
 void
 init_tracing(void);
 
+void
+init_trace_printk(void);
+
 bool
 read_trace_event(struct trace_event *e, u32 timeout_ticks);
 
@@ -270,6 +273,12 @@ tracing_is_enabled(void)
    return __tracing_on;
 }
 
+static ALWAYS_INLINE bool
+trace_printk_is_enabled(void)
+{
+   return tracing_is_enabled();
+}
+
 static ALWAYS_INLINE void
 tracing_set_force_exp_block(bool enabled)
 {
@@ -328,7 +337,7 @@ tracing_set_printk_lvl(int lvl)
    }
 
 #define trace_printk(lvl, fmt, ...)                                            \
-   if (MOD_tracing && UNLIKELY(tracing_is_enabled())) {                        \
+   if (MOD_tracing && UNLIKELY(trace_printk_is_enabled())) {                   \
       trace_printk_int((lvl), fmt, ##__VA_ARGS__);                             \
    }
 

--- a/include/tilck/mods/tracing.h
+++ b/include/tilck/mods/tracing.h
@@ -8,6 +8,7 @@
 #define INVALID_SYSCALL           ((u32) -1)
 #define NO_SLOT                           -1
 #define TRACED_SYSCALLS_STR_LEN         128u
+#define TRACE_PRINTK_TRUNC_STR       "{...}"
 
 enum trace_event_type {
    te_invalid,

--- a/include/tilck/mods/tracing.h
+++ b/include/tilck/mods/tracing.h
@@ -276,7 +276,7 @@ tracing_is_enabled(void)
 static ALWAYS_INLINE bool
 trace_printk_is_enabled(void)
 {
-   return tracing_is_enabled();
+   return TRACE_PRINTK_ENABLED_ON_BOOT || tracing_is_enabled();
 }
 
 static ALWAYS_INLINE void

--- a/include/tilck/mods/tracing.h
+++ b/include/tilck/mods/tracing.h
@@ -43,8 +43,10 @@ struct syscall_event_data {
 };
 
 struct printk_event_data {
-   int level;      /* Verbosity level. Must be > 1 */
-   char buf[192];  /* Actual log entry */
+   short level;      /* Verbosity level. Must be > 1 */
+   bool in_irq;
+   bool __unused_0;
+   char buf[192];    /* Actual log entry */
 };
 
 struct signal_event_data {
@@ -179,10 +181,10 @@ trace_syscall_exit_int(u32 sys,
                        ulong a6);
 
 void
-trace_printk_raw_int(int level, const char *buf, size_t buf_size);
+trace_printk_raw_int(short level, const char *buf, size_t buf_size);
 
 ATTR_PRINTF_LIKE(2) void
-trace_printk_int(int level, const char *fmt, ...);
+trace_printk_int(short level, const char *fmt, ...);
 
 void
 trace_signal_delivered_int(int target_tid, int signum);

--- a/include/tilck/mods/tracing.h
+++ b/include/tilck/mods/tracing.h
@@ -177,6 +177,9 @@ trace_syscall_exit_int(u32 sys,
                        ulong a5,
                        ulong a6);
 
+void
+trace_printk_raw_int(int level, const char *buf, size_t buf_size);
+
 ATTR_PRINTF_LIKE(2) void
 trace_printk_int(int level, const char *fmt, ...);
 
@@ -340,6 +343,12 @@ tracing_set_printk_lvl(int lvl)
    if (MOD_tracing && UNLIKELY(trace_printk_is_enabled())) {                   \
       trace_printk_int((lvl), fmt, ##__VA_ARGS__);                             \
    }
+
+#define trace_printk_raw(lvl, buf, buf_sz)                                     \
+   if (MOD_tracing && UNLIKELY(trace_printk_is_enabled())) {                   \
+      trace_printk_raw_int((lvl), (buf), (buf_sz));                            \
+   }
+
 
 #define trace_signal_delivered(target_tid, signum)                             \
    if (MOD_tracing && UNLIKELY(tracing_is_enabled())) {                        \

--- a/kernel/misc.c
+++ b/kernel/misc.c
@@ -81,9 +81,10 @@ show_system_info(void)
    const int time_slice = 1000 / (TIMER_HZ / TIME_SLICE_TICKS);
    const char *in_hyp_str = in_hypervisor() ? "yes" : "no";
 
-   printk("timer_hz: \e[1m%i\e[m", TIMER_HZ);
-   printk("; time_slice: \e[1m%i\e[m", time_slice);
-   printk(" ms; in_hypervisor: \e[1m%s\e[m\n", in_hyp_str);
+   printk("\e[32mtimer_hz: \e[m\e[1m%i\e[m\e[32m"
+          "; time_slice: \e[m\e[1m%i\e[m\e[32m"
+          " ms; in_hypervisor: \e[m\e[1m%s\e[m\n",
+          TIMER_HZ, time_slice, in_hyp_str);
 }
 
 void
@@ -92,25 +93,23 @@ show_hello_message(void)
    struct commit_hash_and_date comm;
    extract_commit_hash_and_date(&tilck_build_info, &comm);
 
-   if (VER_PATCH > 0)
-      printk("Hello from Tilck \e[1m%d.%d.%d\e[m",
-             VER_MAJOR, VER_MINOR, VER_PATCH);
-   else
-      printk("Hello from Tilck \e[1m%d.%d\e[m",
-             VER_MAJOR, VER_MINOR);
+   printk("\e[32mHello from Tilck \e[m\e[1m%d.%d.%d\e[m\e[32m, "
+          "commit: \e[m\e[1m%s\e[m\e[32m (%s)\e[m\n",
+          VER_MAJOR, VER_MINOR, VER_PATCH,
+          comm.hash,
+          comm.dirty
+            ? "dirty"
+            : comm.tags[0]
+               ? comm.tags
+               : "untagged");
 
-   printk(", commit: \e[1m%s\e[m", comm.hash);
-
-   if (comm.dirty)
-      printk(" (dirty)");
-   else if (comm.tags[0])
-      printk(" (%s)", comm.tags);
-
-   printk("\n");
-   printk("Build type: \e[1m%s\e[m", BUILDTYPE_STR);
-   printk(", compiler: \e[1m%s %d.%d.%d\e[m\n",
+   printk("\e[32mBuild type: \e[m\e[1m%s\e[m\e[32m, "
+          "compiler: \e[m\e[1m%s %d.%d.%d\e[m\n",
+          BUILDTYPE_STR,
           COMPILER_NAME,
-          COMPILER_MAJOR, COMPILER_MINOR, COMPILER_PATCHLEVEL);
+          COMPILER_MAJOR,
+          COMPILER_MINOR,
+          COMPILER_PATCHLEVEL);
 
    show_system_info();
 

--- a/modules/debugpanel/dp_tracing.c
+++ b/modules/debugpanel/dp_tracing.c
@@ -185,6 +185,7 @@ dp_dump_trace_printk_event(struct trace_event *e)
    size_t max_len = sizeof(e->p_ev.buf) - 1;
    const char *buf = e->p_ev.buf;
    const char *trunc = "";
+   const char *log_color = "";
    size_t len;
 
    if (*buf == '\n') {
@@ -234,9 +235,13 @@ dp_dump_trace_printk_event(struct trace_event *e)
       trunc = E_COLOR_BR_RED TRACE_PRINTK_TRUNC_STR RESET_ATTRS;
    }
 
+   if (len >= 4 && !strncmp(buf, "*** ", 4)) {
+      log_color = ATTR_BOLD;
+   }
+
    dp_write_raw(
-      E_COLOR_YELLOW "LOG" RESET_ATTRS "[%02d]: %.*s%s%s",
-      e->p_ev.level, len, buf, trunc, endstr
+      E_COLOR_YELLOW "LOG" RESET_ATTRS "[%02d]: %s%.*s%s%s",
+      e->p_ev.level, log_color, len, buf, trunc, endstr
    );
 }
 

--- a/modules/debugpanel/termutil.h
+++ b/modules/debugpanel/termutil.h
@@ -20,6 +20,7 @@
 #define E_COLOR_CYAN             "\033[36m"
 #define E_COLOR_BR_CYAN          "\033[96m"
 #define E_COLOR_WHITE_ON_RED     "\033[97;41m"
+#define ATTR_BOLD                "\033[1m"
 #define RESET_ATTRS              "\033[0m"
 #define GFX_ON                   "\033(0"
 #define GFX_OFF                  "\033(B"

--- a/modules/pci/generic_x86/pci.c
+++ b/modules/pci/generic_x86/pci.c
@@ -458,6 +458,7 @@ pci_dump_device_info(struct pci_device_loc loc,
 {
    struct pci_device_class dc = {0};
    const char *vendor;
+   char prefix[64];
 
    dc.class_id = nfo->class_id;
    dc.subclass_id = nfo->subclass_id;
@@ -466,47 +467,55 @@ pci_dump_device_info(struct pci_device_loc loc,
    pci_find_device_class_name(&dc);
    vendor = pci_find_vendor_name(nfo->vendor_id);
 
-   printk("PCI: %04x:%02x:%02x.%x: ", loc.seg, loc.bus, loc.dev, loc.func);
+   snprintk(prefix, sizeof(prefix),
+            "PCI: %04x:%02x:%02x.%x",
+            loc.seg, loc.bus, loc.dev, loc.func);
 
    if (dc.subclass_name && dc.progif_name) {
 
-      if (vendor)
-         printk("%s: %s %s\n", dc.subclass_name, vendor, dc.progif_name);
-      else
-         printk("%s (%s)\n", dc.subclass_name, dc.progif_name);
+      if (vendor) {
+         printk("%s: %s: %s %s\n",
+                prefix, dc.subclass_name, vendor, dc.progif_name);
+      } else {
+         printk("%s: %s (%s)\n", prefix, dc.subclass_name, dc.progif_name);
+      }
 
    } else if (dc.subclass_name) {
 
       if (vendor)
-         printk("%s: %s\n", dc.subclass_name, vendor);
+         printk("%s: %s: %s\n", prefix, dc.subclass_name, vendor);
       else
-         printk("%s\n", dc.subclass_name);
+         printk("%s: %s\n", prefix, dc.subclass_name);
 
    } else if (dc.class_name) {
 
       if (vendor) {
 
          if (dc.subclass_id)
-            printk("%s: %s (subclass: %#x)\n",
-                   dc.class_name, vendor, dc.subclass_id);
+            printk("%s: %s: %s (subclass: %#x)\n",
+                   prefix, dc.class_name, vendor, dc.subclass_id);
          else
-            printk("%s: %s\n", dc.class_name, vendor);
+            printk("%s: %s: %s\n", prefix, dc.class_name, vendor);
 
       } else {
 
-         if (dc.subclass_id)
-            printk("%s (subclass: %#x)\n", dc.class_name, dc.subclass_id);
-         else
-            printk("%s\n", dc.class_name);
+         if (dc.subclass_id) {
+            printk("%s: %s (subclass: %#x)\n",
+                   prefix, dc.class_name, dc.subclass_id);
+         } else {
+            printk("%s: %s\n", prefix, dc.class_name);
+         }
       }
 
    } else {
 
-      if (vendor)
-         printk("vendor: %s, class: %#x, subclass: %#x\n",
-                vendor, dc.class_id, dc.subclass_id);
-      else
-         printk("class: %#x, subclass: %#x\n", dc.class_id, dc.subclass_id);
+      if (vendor) {
+         printk("%s: vendor: %s, class: %#x, subclass: %#x\n",
+                prefix, vendor, dc.class_id, dc.subclass_id);
+      } else {
+         printk("%s: class: %#x, subclass: %#x\n",
+                prefix, dc.class_id, dc.subclass_id);
+      }
    }
 }
 

--- a/modules/tracing/tracing.c
+++ b/modules/tracing/tracing.c
@@ -334,7 +334,7 @@ trace_syscall_exit_int(u32 sys,
 }
 
 void
-trace_printk_raw_int(int level, const char *buf, size_t buf_size)
+trace_printk_raw_int(short level, const char *buf, size_t buf_size)
 {
    ASSERT(level >= 1);
 
@@ -359,7 +359,7 @@ trace_printk_raw_int(int level, const char *buf, size_t buf_size)
 }
 
 void
-trace_printk_int(int level, const char *fmt, ...)
+trace_printk_int(short level, const char *fmt, ...)
 {
    va_list args;
    int written;
@@ -377,6 +377,7 @@ trace_printk_int(int level, const char *fmt, ...)
       .sys_time = get_sys_time(),
       .p_ev = {
          .level = level,
+         .in_irq = in_irq(),
       }
    };
 

--- a/modules/tracing/tracing.c
+++ b/modules/tracing/tracing.c
@@ -362,6 +362,7 @@ void
 trace_printk_int(int level, const char *fmt, ...)
 {
    va_list args;
+   int written;
    ASSERT(level >= 1);
 
    if (!__trace_printk_initialized)
@@ -380,8 +381,15 @@ trace_printk_int(int level, const char *fmt, ...)
    };
 
    va_start(args, fmt);
-   vsnprintk(e.p_ev.buf, sizeof(e.p_ev.buf), fmt, args);
+   written = vsnprintk(e.p_ev.buf, sizeof(e.p_ev.buf), fmt, args);
    va_end(args);
+
+   if (written == (int)sizeof(e.p_ev.buf)) {
+      char trunc[] = TRACE_PRINTK_TRUNC_STR;
+      memcpy(e.p_ev.buf + sizeof(e.p_ev.buf) - sizeof(trunc),
+             trunc,
+             sizeof(trunc));
+   }
 
    enqueue_trace_event(&e);
 }

--- a/modules/tracing/tracing.c
+++ b/modules/tracing/tracing.c
@@ -384,11 +384,21 @@ trace_printk_int(int level, const char *fmt, ...)
    written = vsnprintk(e.p_ev.buf, sizeof(e.p_ev.buf), fmt, args);
    va_end(args);
 
-   if (written == (int)sizeof(e.p_ev.buf)) {
+   if (UNLIKELY(written == 0))
+      return;
+
+   if (UNLIKELY(written == (int)sizeof(e.p_ev.buf))) {
+
       char trunc[] = TRACE_PRINTK_TRUNC_STR;
       memcpy(e.p_ev.buf + sizeof(e.p_ev.buf) - sizeof(trunc),
              trunc,
              sizeof(trunc));
+
+   } else if (e.p_ev.buf[written - 1] != '\n') {
+
+      ASSERT(e.p_ev.buf[written] == '\0');
+      e.p_ev.buf[written] = '\n';
+      e.p_ev.buf[written + 1] = '\0';
    }
 
    enqueue_trace_event(&e);

--- a/modules/tracing/tracing_metadata.c
+++ b/modules/tracing/tracing_metadata.c
@@ -378,6 +378,27 @@ static const struct syscall_info __tracing_metadata[] =
    },
 #endif
 
+   {
+      .sys_n = SYS_getrusage,
+      .n_params = 2,
+      .exp_block = false,
+      .ret_type = &ptype_errno_or_val,
+      .params = {
+         SIMPLE_PARAM("who", &ptype_int, sys_param_in),
+         SIMPLE_PARAM("usage", &ptype_voidp, sys_param_out),
+      },
+   },
+
+   {
+      .sys_n = TILCK_CMD_SYSCALL,
+      .n_params = 1,
+      .exp_block = false,
+      .ret_type = &ptype_errno_or_val,
+      .params = {
+         SIMPLE_PARAM("cmd", &ptype_int, sys_param_in),
+      },
+   },
+
 #else
 
 /*


### PR DESCRIPTION
This series of patches makes possible `trace_printk()` to be initialized independently from the rest of the `tracing` module and makes `printk()` store the log messages in the `trace_printk()` buffer as well. This was challenging since `printk()` works in many contexts including IRQs handlers (while `trace_printk()` didn't) and also `printk()` have a different semantic compared to `trace_printk()`: `printk()` doesn't force single-line messages and a new line at the end of it is optional. That is also required by the ACPICA log function. On the other side, `trace_printk()` was designed to be used as a pure logger. Now, with quite many tricks, all the `printk()` messages go to the `trace_printk()` buffer, even the early boot messages that are kept initially in the ringbuffer. Many `printk()` have been converted to write a single statement in one call. In addition to that, to support the ACPICA logs, the `dp_tracer` code has been made to automatically collapse multiple trace printk events, when they don't have a line ending and are in the same context. Therefore, in summary, now it's possible to see unstructured `printk()` statements as log statements with TID, timestamp etc.

Because of this effort, now the debugging experience will be much better, as in one place we could see all the messages and see all the syscalls and the other events interleaving.