### PR TITLE
[fault] Check running_in_kernel is not set before process_signals()

### DIFF
--- a/kernel/interrupts.c
+++ b/kernel/interrupts.c
@@ -271,7 +271,9 @@ void fault_entry(regs_t *r)
     * still disabled.
     */
    pop_nested_interrupt();
-   process_signals(get_curr_task(), sig_in_fault, r);
+
+   if (!get_curr_task()->running_in_kernel)
+      process_signals(get_curr_task(), sig_in_fault, r);
 
    enable_preemption();
    disable_interrupts_forced();


### PR DESCRIPTION
Hi @vvaltchev

If a user space program has a page fault during syscall and COW occurs, then when the page fault returns to `fault_entry()` and `process_signal()` is going to be called, the `regs_t `pointer passed to `process_signal()` is for the kernel context. If the current has a pending signal at this point, `setup_sig_handler()` may fail because `process_signal()` expects to receive `regs_t `parameter for the user-space context
