### PR TITLE
[interrupts] Disable irq if do_schedule() just returned in irq_resched()

### DIFF
--- a/kernel/interrupts.c
+++ b/kernel/interrupts.c
@@ -188,6 +188,9 @@ static void irq_resched(regs_t *r)
 
       /* Call do_schedule() with preemption disabled, as mandatory */
       do_schedule();
+
+      /* Disable the interrupts, if do_schedule() just returned */
+      disable_interrupts_forced();
    }
 }
 


### PR DESCRIPTION
Hi @vvaltchev 

In` irq_resched()`,  if `do_schedule()` just returned, then `irq_entry()` will return with interrupts enabled! This doesn't seem to cause any problems with the i386 architecture. But for developers trying to port tilck to other architectures, they often assume that the interrupt is off when `irq_entry()` returns. Therefore, disable interrupts here to avoid causing confusion for developers.