### PR TITLE
[riscv64] early init code

### DIFF
--- a/common/3rd_party/fdt_helper.c
+++ b/common/3rd_party/fdt_helper.c
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * fdt_helper.c - Flat Device Tree manipulation helper routines
+ * Implement helper routines on top of libfdt for OpenSBI usage
+ *
+ * Copyright (C) 2020 Bin Meng <bmeng.cn@gmail.com>
+ *
+ * Tilck changes & notes
+ * -----------------------
+ *
+ * There are a lot of deletions compared to the original text.
+ */
+
+
+#include <tilck/common/basic_defs.h>
+#include <tilck/common/printk.h>
+#include <tilck/kernel/errno.h>
+
+#include <3rd_party/fdt_helper.h>
+#include <libfdt.h>
+
+const struct fdt_match *fdt_match_node(void *fdt, int nodeoff,
+                   const struct fdt_match *match_table)
+{
+   int ret;
+
+   if (!fdt || nodeoff < 0 || !match_table)
+      return NULL;
+
+   while (match_table->compatible) {
+      ret = fdt_node_check_compatible(fdt, nodeoff,
+                  match_table->compatible);
+      if (!ret)
+         return match_table;
+      match_table++;
+   }
+
+   return NULL;
+}
+
+int fdt_find_match(void *fdt, int startoff,
+         const struct fdt_match *match_table,
+         const struct fdt_match **out_match)
+{
+   int nodeoff;
+
+   if (!fdt || !match_table)
+      return -ENODEV;
+
+   while (match_table->compatible) {
+      nodeoff = fdt_node_offset_by_compatible(fdt, startoff,
+                  match_table->compatible);
+      if (nodeoff >= 0) {
+         if (out_match)
+            *out_match = match_table;
+         return nodeoff;
+      }
+      match_table++;
+   }
+
+   return -ENODEV;
+}
+
+int fdt_parse_phandle_with_args(void *fdt, int nodeoff,
+            const char *prop, const char *cells_prop,
+            int index, struct fdt_phandle_args *out_args)
+{
+   u32 i, pcells;
+   int len, pnodeoff;
+   const fdt32_t *list, *list_end, *val;
+
+   if (!fdt || (nodeoff < 0) || !prop || !cells_prop || !out_args)
+      return -EINVAL;
+
+   list = fdt_getprop(fdt, nodeoff, prop, &len);
+   if (!list)
+      return -ENOENT;
+   list_end = list + (len / sizeof(*list));
+
+   while (list < list_end) {
+      pnodeoff = fdt_node_offset_by_phandle(fdt,
+                  fdt32_to_cpu(*list));
+      if (pnodeoff < 0)
+         return pnodeoff;
+      list++;
+
+      val = fdt_getprop(fdt, pnodeoff, cells_prop, &len);
+      if (!val)
+         return -ENOENT;
+      pcells = fdt32_to_cpu(*val);
+      if (FDT_MAX_PHANDLE_ARGS < pcells)
+         return -EINVAL;
+      if (list + pcells > list_end)
+         return -ENOENT;
+
+      if (index > 0) {
+         list += pcells;
+         index--;
+      } else {
+         out_args->node_offset = pnodeoff;
+         out_args->args_count = pcells;
+         for (i = 0; i < pcells; i++)
+            out_args->args[i] = fdt32_to_cpu(list[i]);
+         return 0;
+      }
+   }
+
+   return -ENOENT;
+}
+
+static int fdt_translate_address(void *fdt, uint64_t reg, int parent,
+             uint64_t *addr)
+{
+   int i, rlen;
+   int cell_addr, cell_size;
+   const fdt32_t *ranges;
+   uint64_t offset, caddr = 0, paddr = 0, rsize = 0;
+
+   cell_addr = fdt_address_cells(fdt, parent);
+   if (cell_addr < 1)
+      return -ENODEV;
+
+   cell_size = fdt_size_cells(fdt, parent);
+   if (cell_size < 0)
+      return -ENODEV;
+
+   ranges = fdt_getprop(fdt, parent, "ranges", &rlen);
+   if (ranges && rlen > 0) {
+      for (i = 0; i < cell_addr; i++)
+         caddr = (caddr << 32) | fdt32_to_cpu(*ranges++);
+      for (i = 0; i < cell_addr; i++)
+         paddr = (paddr << 32) | fdt32_to_cpu(*ranges++);
+      for (i = 0; i < cell_size; i++)
+         rsize = (rsize << 32) | fdt32_to_cpu(*ranges++);
+      if (reg < caddr || caddr >= (reg + rsize )) {
+         printk("invalid address translation\n");
+         return -ENODEV;
+      }
+      offset = reg - caddr;
+      *addr = paddr + offset;
+   } else {
+      /* No translation required */
+      *addr = reg;
+   }
+
+   return 0;
+}
+
+int fdt_get_node_addr_size(void *fdt, int node, int index,
+            uint64_t *addr, uint64_t *size)
+{
+   int parent, len, i, rc;
+   int cell_addr, cell_size;
+   const fdt32_t *prop_addr, *prop_size;
+   uint64_t temp = 0;
+
+   if (!fdt || node < 0 || index < 0)
+      return -EINVAL;
+
+   parent = fdt_parent_offset(fdt, node);
+   if (parent < 0)
+      return parent;
+   cell_addr = fdt_address_cells(fdt, parent);
+   if (cell_addr < 1)
+      return -ENODEV;
+
+   cell_size = fdt_size_cells(fdt, parent);
+   if (cell_size < 0)
+      return -ENODEV;
+
+   prop_addr = fdt_getprop(fdt, node, "reg", &len);
+   if (!prop_addr)
+      return -ENODEV;
+
+   if ((len / sizeof(u32)) <= (ulong)(index * (cell_addr + cell_size)))
+      return -EINVAL;
+
+   prop_addr = prop_addr + (index * (cell_addr + cell_size));
+   prop_size = prop_addr + cell_addr;
+
+   if (addr) {
+      for (i = 0; i < cell_addr; i++)
+         temp = (temp << 32) | fdt32_to_cpu(*prop_addr++);
+      do {
+         if (parent < 0)
+            break;
+         rc  = fdt_translate_address(fdt, temp, parent, addr);
+         if (rc)
+            break;
+         parent = fdt_parent_offset(fdt, parent);
+         temp = *addr;
+      } while (1);
+   }
+   temp = 0;
+
+   if (size) {
+      for (i = 0; i < cell_size; i++)
+         temp = (temp << 32) | fdt32_to_cpu(*prop_size++);
+      *size = temp;
+   }
+
+   return 0;
+}
+
+int fdt_get_node_addr_size_by_name(void *fdt, int node, const char *name,
+               uint64_t *addr, uint64_t *size)
+{
+   int i, j, count;
+   const char *val;
+   const char *regname;
+
+   if (!fdt || node < 0 || !name)
+      return -EINVAL;
+
+   val = fdt_getprop(fdt, node, "reg-names", &count);
+   if (!val)
+      return -ENODEV;
+
+   for (i = 0, j = 0; i < count; i++, j++) {
+      regname = val + i;
+
+      if (strcmp(name, regname) == 0)
+         return fdt_get_node_addr_size(fdt, node, j, addr, size);
+
+      i += strlen(regname);
+   }
+
+   return -ENODEV;
+}
+
+bool fdt_node_is_enabled(void *fdt, int nodeoff)
+{
+   int len;
+   const void *prop;
+
+   prop = fdt_getprop(fdt, nodeoff, "status", &len);
+   if (!prop)
+      return true;
+
+   if (!strncmp(prop, "okay", strlen("okay")))
+      return true;
+
+   if (!strncmp(prop, "ok", strlen("ok")))
+      return true;
+
+   return false;
+}

--- a/include/3rd_party/fdt_helper.h
+++ b/include/3rd_party/fdt_helper.h
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * fdt_helper.h - Flat Device Tree parsing helper routines
+ * Implement helper routines to parse FDT nodes on top of
+ * libfdt for OpenSBI usage
+ *
+ * Copyright (C) 2020 Bin Meng <bmeng.cn@gmail.com>
+ */
+
+#ifndef __FDT_HELPER_H__
+#define __FDT_HELPER_H__
+
+#include <tilck/common/basic_defs.h>
+
+struct fdt_match {
+   const char *compatible;
+   const void *data;
+};
+
+#define FDT_MAX_PHANDLE_ARGS 16
+struct fdt_phandle_args {
+   int node_offset;
+   int args_count;
+   u32 args[FDT_MAX_PHANDLE_ARGS];
+};
+
+const struct fdt_match *fdt_match_node(void *fdt, int nodeoff,
+                   const struct fdt_match *match_table);
+
+int fdt_find_match(void *fdt, int startoff,
+         const struct fdt_match *match_table,
+         const struct fdt_match **out_match);
+
+int fdt_parse_phandle_with_args(void *fdt, int nodeoff,
+            const char *prop, const char *cells_prop,
+            int index, struct fdt_phandle_args *out_args);
+
+int fdt_get_node_addr_size(void *fdt, int node, int index,
+            uint64_t *addr, uint64_t *size);
+
+int fdt_get_node_addr_size_by_name(void *fdt, int node, const char *name,
+               uint64_t *addr, uint64_t *size);
+
+bool fdt_node_is_enabled(void *fdt, int nodeoff);
+
+#endif /* __FDT_HELPER_H__ */

--- a/include/tilck/common/arch/riscv/image.h
+++ b/include/tilck/common/arch/riscv/image.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#pragma once
+
+#ifndef __riscv
+   #error This header can be used only when building for riscv.
+#endif
+
+/* riscv kernel image header */
+struct linux_image_h {
+   u32 code0;        /* Executable code */
+   u32 code1;        /* Executable code */
+   u64 text_offset;  /* Image load offset */
+   u64 image_size;   /* Effective Image size */
+   u64 flags;        /* kernel flags (little endian) */
+   u32 version;      /* version of the header */
+   u32 res1;         /* reserved */
+   u64 res2;         /* reserved */
+   u64 res3;         /* reserved */
+   u32 magic;        /* Magic number */
+   u32 res4;         /* reserved */
+};

--- a/include/tilck/kernel/arch/riscv/arch_utils.h
+++ b/include/tilck/kernel/arch/riscv/arch_utils.h
@@ -101,8 +101,8 @@ static ALWAYS_INLINE void *regs_get_ip(regs_t *r)
 
 static ALWAYS_INLINE u32 get_boothartid(void)
 {
-   extern u32 boot_cpu_hartid;
-   return boot_cpu_hartid;
+   extern u32 _boot_cpu_hartid;
+   return _boot_cpu_hartid;
 }
 
 static ALWAYS_INLINE void *fdt_get_address(void)

--- a/include/tilck/kernel/arch/riscv/sbi.h
+++ b/include/tilck/kernel/arch/riscv/sbi.h
@@ -1,0 +1,110 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#pragma once
+
+#include <tilck/common/basic_defs.h>
+
+/* Standard SBI Errors */
+#define SBI_SUCCESS                 0
+#define SBI_ERR_FAILURE            -1
+#define SBI_ERR_NOT_SUPPORTED      -2
+#define SBI_ERR_INVALID_PARAM      -3
+#define SBI_ERR_DENIED             -4
+#define SBI_ERR_INVALID_ADDRESS    -5
+#define SBI_ERR_ALREADY_AVAILABLE  -6
+#define SBI_ERR_ALREADY_STARTED    -7
+#define SBI_ERR_ALREADY_STOPPED    -8
+#define SBI_ERR_NO_SHMEM           -9
+#define SBI_ERR_INVALID_STATE      -10
+#define SBI_ERR_BAD_RANGE          -11
+
+/* Legacy Extensions */
+#define SBI_SET_TIMER                0
+#define SBI_CONSOLE_PUTCHAR          1
+#define SBI_CONSOLE_GETCHAR          2
+#define SBI_CLEAR_IPI                3
+#define SBI_SEND_IPI                 4
+#define SBI_REMOTE_FENCE_I           5
+#define SBI_REMOTE_SFENCE_VMA        6
+#define SBI_REMOTE_SFENCE_VMA_ASID   7
+#define SBI_SHUTDOWN                 8
+
+/* SBI Base Extension */
+#define SBI_BASE_EXT_ID             0x10
+#define SBI_BASE_GET_SPEC_VERSION   0
+#define SBI_BASE_GET_IMPL_ID        1
+#define SBI_BASE_GET_IMPL_VERSION   2
+#define SBI_BASE_PROBE_EXTENSION    3
+#define SBI_BASE_GET_MVENDORID      4
+#define SBI_BASE_GET_MARCHID        5
+#define SBI_BASE_GET_MIMPID         6
+
+/* System Reset (SRST) Extension */
+#define SBI_SRST_EXT_ID                  0x53525354
+#define SBI_SRST_SYSTEM_RESET            0
+#define SBI_SRST_TYPE_SHUTDOWN           0
+#define SBI_SRST_TYPE_COLD_REBOOT        1
+#define SBI_SRST_TYPE_WARM_REBOOT        2
+#define SBI_SRST_REASON_NONE             0
+#define SBI_SRST_REASON_SYSTEM_FAILURE   1
+
+#define SBI_CALL0(e, f)                     sbi_call(e, f, 0, 0, 0, 0, 0)
+#define SBI_CALL1(e, f, a0)                 sbi_call(e, f, a0, 0, 0, 0, 0)
+#define SBI_CALL2(e, f, a0, a1)             sbi_call(e, f, a0, a1, 0, 0, 0)
+#define SBI_CALL3(e, f, a0, a1, a2)         sbi_call(e, f, a0, a1, a2, 0, 0)
+#define SBI_CALL4(e, f, a0, a1, a2, a3)     sbi_call(e, f, a0, a1, a2, a3, 0)
+#define SBI_CALL5(e, f, a0, a1, a2, a3, a4) \
+   sbi_call(e, f, a0, a1, a2, a3, a4)
+
+struct sbiret {
+   long error;
+   long value;
+};
+
+static ALWAYS_INLINE struct sbiret
+sbi_call(ulong eid,
+         ulong fid,
+         ulong arg0,
+         ulong arg1,
+         ulong arg2,
+         ulong arg3,
+         ulong arg4)
+{
+   struct sbiret rc;
+
+   register ulong a0 __asm__ ("a0") = (ulong)(arg0);
+   register ulong a1 __asm__ ("a1") = (ulong)(arg1);
+   register ulong a2 __asm__ ("a2") = (ulong)(arg2);
+   register ulong a3 __asm__ ("a3") = (ulong)(arg3);
+   register ulong a4 __asm__ ("a4") = (ulong)(arg4);
+   register ulong a6 __asm__ ("a6") = (ulong)(fid);
+   register ulong a7 __asm__ ("a7") = (ulong)(eid);
+
+   asmVolatile("ecall"
+               :"+r"(a0), "+r"(a1)
+               :"r"(a2), "r"(a3), "r"(a4), "r"(a6), "r"(a7)
+               :"memory");
+
+   rc.error = a0;
+   rc.value = a1;
+   return (rc);
+}
+
+static ALWAYS_INLINE long sbi_set_timer(u64 value)
+{
+   return SBI_CALL1(SBI_SET_TIMER, 0, value).error;
+}
+
+static ALWAYS_INLINE long sbi_console_putchar(int ch)
+{
+   return SBI_CALL1(SBI_CONSOLE_PUTCHAR, 0, ch).error;
+}
+
+struct sbiret sbi_get_spec_version(void);
+struct sbiret sbi_get_impl_id(void);
+struct sbiret sbi_get_impl_version(void);
+struct sbiret sbi_get_mvendorid(void);
+struct sbiret sbi_get_marchid(void);
+struct sbiret sbi_get_mimpid(void);
+void sbi_system_reset(u32 type, u32 reason);
+void sbi_shutdown(void);

--- a/include/tilck/kernel/hal.h
+++ b/include/tilck/kernel/hal.h
@@ -34,6 +34,8 @@
 
    #include <tilck/common/arch/riscv/riscv_utils.h>
    #include <tilck/common/arch/riscv/utils.h>
+   #include <tilck/common/arch/riscv/image.h>
+   #include <tilck/kernel/arch/riscv/sbi.h>
    #include <tilck/kernel/arch/riscv/mmio.h>
    #include <tilck/kernel/arch/riscv/ioremap.h>
    #include <tilck/kernel/arch/riscv/arch_ints.h>

--- a/kernel/arch/riscv/cpu_features.c
+++ b/kernel/arch/riscv/cpu_features.c
@@ -7,13 +7,293 @@
 #include <tilck/common/string_util.h>
 #include <tilck/common/arch/riscv/riscv_utils.h>
 #include <tilck/kernel/hal.h>
+#include <3rd_party/fdt_helper.h>
+#include <libfdt.h>
+
+#define ANDESTECH_VENDOR_ID   0x31e
+#define SIFIVE_VENDOR_ID      0x489
+#define THEAD_VENDOR_ID       0x5b7
+
+/*
+ * Svpbmt custom page attribute bits:
+ */
+#define _PAGE_PMA_SVPBMT       (0UL)
+#define _PAGE_NOCACHE_SVPBMT   (1UL << 61)
+#define _PAGE_IO_SVPBMT        (1UL << 62)
+#define _PAGE_MTMASK_SVPBMT    (_PAGE_NOCACHE_SVPBMT | _PAGE_IO_SVPBMT)
+
+/*
+ * T-Head custom page attribute bits:
+ */
+#define _PAGE_PMA_THEAD      ((1UL << 62) | (1UL << 61) | (1UL << 60))
+#define _PAGE_NOCACHE_THEAD  (0UL)
+#define _PAGE_IO_THEAD       (1UL << 63)
+#define _PAGE_MTMASK_THEAD   (_PAGE_PMA_THEAD | _PAGE_IO_THEAD | (1UL << 59))
+
+volatile struct riscv_cpu_features riscv_cpu_features;
+static char isa_string_buf[128];
+static char isa_ext_string_buf[1024];
+static char model_name[64];
+
+static const char *isa_exts_names[] =
+{
+   "i",
+   "m",
+   "a",
+   "f",
+   "d",
+   "q",
+   "c",
+   "b",
+   "k",
+   "j",
+   "p",
+   "v",
+   "h",
+   "zicbom",
+   "zicboz",
+   "zicntr",
+   "zicsr",
+   "zifencei",
+   "zihintpause",
+   "zihpm",
+   "zba",
+   "zbb",
+   "zbs",
+   "smaia",
+   "ssaia",
+   "sscofpmf",
+   "sstc",
+   "svinval",
+   "svnapot",
+   "svpbmt",
+};
+
+static int fdt_parse_model(void *fdt)
+{
+   int node, len;
+   const fdt32_t *prop;
+
+   node = fdt_path_offset(fdt, "/");
+   if (node < 0)
+      return -1;
+
+   prop = fdt_getprop(fdt, node, "model", &len);
+   if (!prop || !len)
+      return -1;
+
+   strncpy(model_name, (const char *)prop, sizeof(model_name));
+
+   return 0;
+}
+
+static int
+fdt_parse_hart_id(void *fdt, int cpu_offset, u32 *hartid)
+{
+   int len;
+   const void *prop;
+   const fdt32_t *val;
+
+   if (!fdt || cpu_offset < 0)
+      return -1;
+
+   prop = fdt_getprop(fdt, cpu_offset, "device_type", &len);
+   if (!prop || !len)
+      return -1;
+   if (strncmp (prop, "cpu", strlen ("cpu")))
+      return -1;
+
+   val = fdt_getprop(fdt, cpu_offset, "reg", &len);
+   if (!val || len < (int)sizeof(fdt32_t))
+      return -1;
+
+   if (len > (int)sizeof(fdt32_t))
+      val++;
+
+   if (hartid)
+      *hartid = fdt32_to_cpu(*val);
+
+   return 0;
+}
+
+static int fdt_parse_isa_extensions(void *fdt)
+{
+   int cpu_node, cpus_node, len, rc;
+   u32 hart_id;
+   const fdt32_t *prop;
+
+   cpus_node = fdt_path_offset(fdt, "/cpus");
+   if (cpus_node < 0)
+      return -1;
+
+   fdt_for_each_subnode(cpu_node, fdt, cpus_node) {
+
+      rc = fdt_parse_hart_id(fdt, cpu_node, &hart_id);
+      if (rc)
+         return rc;
+
+      prop = fdt_getprop(fdt, cpu_node, "device_type", NULL);
+
+      if (prop &&
+         !strcmp((void *)prop, "cpu") &&
+          hart_id == get_boothartid())
+      {
+         prop = fdt_getprop(fdt, cpu_node, "riscv,isa", &len);
+         if (prop && len) {
+            strncpy(isa_string_buf, (void *)prop,
+                     sizeof(isa_string_buf));
+         }
+
+         prop = fdt_getprop(fdt, cpu_node, "riscv,isa-extensions", &len);
+         if (prop && len) {
+            memcpy(isa_ext_string_buf, (void *)prop,
+                   MIN((ulong)len, sizeof(isa_ext_string_buf)));
+         }
+
+         return 0;
+      }
+   }
+
+   return -1;
+}
+
+static bool isa_ext_string_match(const char *string)
+{
+   char *buf = isa_ext_string_buf;
+   char *end = buf + strnlen(buf, sizeof(isa_ext_string_buf));
+   char *chr;
+
+   // try isa_ext_string_buf
+
+   for (char *ptr = buf; ptr < end; ptr += strlen(ptr) + 1) {
+
+      if (strcmp(string, ptr) == 0)
+         return true;
+   }
+
+   /*
+    * try isa_string_buf, Some platforms(e.g. qemu-virt) may not have
+    * riscv,isa-extensions property defined in the device tree
+    */
+   buf = isa_string_buf;
+   if (strncmp(buf, "rv64", 4) && strncmp(buf, "rv32", 4))
+      panic("riscv: \"riscv,isa\" property not defined in device tree");
+
+   if (strlen(string) == 1) {
+
+      buf = isa_string_buf;
+      chr = strchr(buf, '_');
+      end = chr ? chr : (buf + strnlen(buf, sizeof(isa_string_buf)));
+
+      for (char *ptr = buf + 4; ptr < end; ptr++) {
+
+         if (*ptr == *string)
+            return true;
+      }
+
+   } else {
+
+      buf = isa_string_buf;
+      end = buf + strnlen(buf, sizeof(isa_string_buf));
+      size_t len;
+
+      for (char *ptr = buf; ptr < end; ptr += len + 1) {
+
+         chr = strchr(ptr, '_');
+         len = (chr ? chr : end) - ptr;
+         if (strncmp(string, ptr, len) == 0)
+            return true;
+   }
+   }
+
+   return false;
+}
+
+/*
+ * We must set the contents of riscv_cpu_features before early_init_paging(),
+ * because when setup the kernel mapping, we have to make sure the vendor
+ * defined page attribute bits are set correctly in riscv_cpu_features.
+ */
+void early_get_cpu_features(void)
+{
+   struct riscv_cpu_features *f = (void *)&riscv_cpu_features;
+
+   bool *flags = (bool *)&f->isa_exts;
+
+   if (sbi_get_spec_version().error) {
+
+      // legacy extensions
+      f->vendor_id = 0;
+      f->arch_id = 0;
+      f->imp_id = 0;
+   } else {
+
+      f->vendor_id = sbi_get_mvendorid().value;
+      f->arch_id = sbi_get_marchid().value;
+      f->imp_id = sbi_get_mimpid().value;
+   }
+
+   fdt_parse_model(fdt_get_address());
+   fdt_parse_isa_extensions(fdt_get_address());
+
+   bzero(&f->isa_exts, sizeof(f->isa_exts));
+
+   for (u32 i = 0; i < ARRAY_SIZE(isa_exts_names); i++) {
+
+      flags[i] = isa_ext_string_match(isa_exts_names[i]) ? true : false;
+   }
+
+   if (f->isa_exts.svpbmt) {
+
+      f->page_mtmask = _PAGE_MTMASK_SVPBMT;
+      f->page_cb =     _PAGE_PMA_SVPBMT;
+      f->page_wt =     _PAGE_NOCACHE_SVPBMT;
+      f->page_io =     _PAGE_IO_SVPBMT;
+
+   } else if (f->vendor_id == THEAD_VENDOR_ID) {
+
+      f->page_mtmask = _PAGE_MTMASK_THEAD;
+      f->page_cb =     _PAGE_PMA_THEAD;
+      f->page_wt =     _PAGE_NOCACHE_THEAD;
+      f->page_io =     _PAGE_IO_THEAD;
+   }
+}
 
 void get_cpu_features(void)
 {
-   NOT_IMPLEMENTED();
+   /*
+    * Already done in early_get_cpu_features(),
+    * here just dump cpu features
+    */
+   dump_riscv_features();
 }
 
 void dump_riscv_features(void)
 {
-   NOT_IMPLEMENTED();
+   char buf[256];
+   u32 w = 0;
+
+   printk("MODEL: %s\n", model_name);
+   printk("VENDOR-ID: 0x%lx ", riscv_cpu_features.vendor_id);
+   printk("ARCH-ID: 0x%lx ", riscv_cpu_features.arch_id);
+   printk("IMP-ID: 0x%lx\n", riscv_cpu_features.imp_id);
+   printk("CPU: %s\n", isa_string_buf);
+   printk("isa-extensions: ");
+
+   bool *flags = (bool *)&riscv_cpu_features.isa_exts;
+
+   for (u32 i = 0; i < ARRAY_SIZE(isa_exts_names); i++) {
+
+      if (flags[i])
+         w += (u32)snprintk(buf + w, sizeof(buf) - w, "%s ", isa_exts_names[i]);
+
+      if (w >= 60) {
+         printk("%s\n", buf);
+         w = 0;
+         buf[0] = 0;
+      }
+   }
+
+   if (w)
+      printk("%s\n", buf);
 }

--- a/kernel/arch/riscv/early_fdt.c
+++ b/kernel/arch/riscv/early_fdt.c
@@ -1,0 +1,399 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+#include <tilck/common/basic_defs.h>
+#include <tilck/common/boot.h>
+#include <tilck/common/string_util.h>
+#include <tilck/common/printk.h>
+#include <tilck/common/utils.h>
+#include <tilck/kernel/errno.h>
+#include <tilck/kernel/hal.h>
+#include <3rd_party/fdt_helper.h>
+#include <libfdt.h>
+#include <multiboot.h>
+#include "paging_int.h"
+
+#define CMDLINE_BUF_SZ 1024
+
+struct simplefb_bitfield {
+   u8 offset;   /* beginning of bitfield */
+   u8 size;       /* length of bitfield */
+};
+
+struct simplefb_format {
+   const char *name;
+   u8 bpp;  /* bits per pixel */
+   struct simplefb_bitfield red;
+   struct simplefb_bitfield green;
+   struct simplefb_bitfield blue;
+   struct simplefb_bitfield alpha;
+};
+
+void *fdt_blob;   //save virtual address of fdt
+
+static ulong initrd_paddr;
+static ulong initrd_size;
+
+static multiboot_info_t *mbi;
+static multiboot_module_t *mod;
+static multiboot_memory_map_t *mmmap;
+
+static int mmmap_count = 0;
+static char *cmdline_buf;
+
+static struct simplefb_format simplefb_formats[] = {
+   {"r5g6b5", 16, {11, 5}, {5, 6}, {0, 5}, {0, 0}},
+   {"r5g5b5a1", 16, {11, 5}, {6, 5}, {1, 5}, {0, 1}},
+   {"x1r5g5b5", 16, {10, 5}, {5, 5}, {0, 5}, {0, 0}},
+   {"a1r5g5b5", 16, {10, 5}, {5, 5}, {0, 5}, {15, 1}},
+   {"r8g8b8", 24, {16, 8}, {8, 8}, {0, 8}, {0, 0}},
+   {"x8r8g8b8", 32, {16, 8}, {8, 8}, {0, 8}, {0, 0}},
+   {"a8r8g8b8", 32, {16, 8}, {8, 8}, {0, 8}, {24, 8}},
+   {"x8b8g8r8", 32, {0, 8}, {8, 8}, {16, 8}, {0, 0}},
+   {"a8b8g8r8", 32, {0, 8}, {8, 8}, {16, 8}, {24, 8}},
+   {"x2r10g10b10", 32, {20, 10}, {10, 10}, {0, 10}, {0, 0}},
+   {"a2r10g10b10", 32, {20, 10}, {10, 10}, {0, 10}, {30, 2}},
+};
+
+void alloc_mbi(void)
+{
+   void *mbi_memtop;
+
+   /*
+    * Place multiboot information at the top of
+    * 8 MB identity mapping space.
+    */
+   mbi_memtop = (void *)(LIN_VA_TO_PA(BASE_VA) + EARLY_MAP_SIZE);
+
+   mbi = (multiboot_info_t *)((ulong)mbi_memtop - sizeof(*mbi));
+   bzero(mbi, sizeof(*mbi));
+
+   mod = (multiboot_module_t *)((ulong)mbi - sizeof(*mod));
+   bzero(mod, sizeof(*mod));
+
+   cmdline_buf = (char *)mod - CMDLINE_BUF_SZ;
+   bzero(cmdline_buf, CMDLINE_BUF_SZ);
+}
+
+static void
+add_multiboot_mmap(u64 addr, u64 size, u32 type)
+{
+   /* Allocate a new multiboot_memory_map */
+   if (!mmmap)
+      mmmap = (void *)(cmdline_buf - sizeof(multiboot_memory_map_t));
+   else
+      mmmap--;
+
+   mmmap_count++;
+
+   bzero(mmmap, sizeof(multiboot_memory_map_t));
+
+   if (addr < mbi->mem_lower * KB)
+      mbi->mem_lower = (u32)(addr / KB);
+
+   if (addr + size > mbi->mem_upper * KB)
+      mbi->mem_upper = (u32)((addr + size) / KB);
+
+   *mmmap = (multiboot_memory_map_t) {
+      .size = sizeof(multiboot_memory_map_t) - sizeof(u32),
+      .addr = addr,
+      .len = size,
+      .type = type,
+   };
+}
+
+void setup_multiboot_info(ulong ramdisk_paddr, ulong ramdisk_size)
+{
+   mbi->flags |= MULTIBOOT_INFO_MEMORY;
+
+   if (cmdline_buf[0]) {
+      mbi->flags |= MULTIBOOT_INFO_CMDLINE;
+      mbi->cmdline = (ulong)cmdline_buf;
+   }
+
+   mbi->flags |= MULTIBOOT_INFO_MODS;
+   mbi->mods_addr = (ulong)mod;
+   mbi->mods_count = 1;
+   mod->mod_start = ramdisk_paddr;
+   mod->mod_end = mod->mod_start + ramdisk_size;
+
+   mbi->flags |= MULTIBOOT_INFO_MEM_MAP;
+   mbi->mmap_addr = (ulong)mmmap;
+   mbi->mmap_length = mmmap_count * sizeof(multiboot_memory_map_t);
+}
+
+static int
+fdt_get_node_linux_usable_memory(void *fdt, int node, int index,
+                                 uint64_t *addr, uint64_t *size)
+{
+   int len, i;
+   int cell_addr, cell_size;
+   const fdt32_t *prop_addr, *prop_size;
+   uint64_t temp = 0;
+
+   if (!fdt || node < 0 || index < 0)
+      return -EINVAL;
+
+   cell_addr = fdt_address_cells(fdt, 0);
+   if (cell_addr < 1)
+      return -ENODEV;
+
+   cell_size = fdt_size_cells(fdt, 0);
+   if (cell_size < 0)
+      return -ENODEV;
+
+   prop_addr = fdt_getprop(fdt, node, "linux,usable-memory", &len);
+   if (!prop_addr)
+      return -ENODEV;
+
+   if ((len / sizeof(u32)) <= (ulong)(index * (cell_addr + cell_size)))
+      return -EINVAL;
+
+   prop_addr = prop_addr + (index * (cell_addr + cell_size));
+   prop_size = prop_addr + cell_addr;
+
+   if (addr) {
+      for (i = 0; i < cell_addr; i++)
+         temp = (temp << 32) | fdt32_to_cpu(*prop_addr++);
+      *addr = temp;
+   }
+
+   temp = 0;
+
+   if (size) {
+      for (i = 0; i < cell_size; i++)
+         temp = (temp << 32) | fdt32_to_cpu(*prop_size++);
+      *size = temp;
+   }
+
+   return 0;
+}
+
+static int
+fdt_add_multiboot_mmap(void *fdt, int node, u32 type)
+{
+   int nomem = 1, index = 0;
+   u64 addr, size;
+
+   while (fdt_get_node_linux_usable_memory(fdt, node, index,
+                                           &addr, &size) == 0)
+   {
+
+      if (size == 0)
+         continue;
+
+      index++;
+      nomem = 0;
+
+      add_multiboot_mmap(addr, size, type);
+   }
+
+   if (!nomem)
+      return 0;
+
+   while (fdt_get_node_addr_size(fdt, node,
+                                 index, &addr, &size) == 0)
+   {
+
+      if (size == 0)
+         continue;
+
+      index++;
+      nomem = 0;
+
+      add_multiboot_mmap(addr, size, type);
+   }
+
+   return nomem;
+}
+
+static inline u64
+fdt_read64(const fdt32_t *cell, size_t size)
+{
+   u64 val_64 = (u64)fdt32_to_cpu(*(cell++));
+
+   if (size >= 8)
+      val_64 = (val_64 << 32) | fdt32_to_cpu(*cell);
+
+   return val_64;
+}
+
+static int fdt_parse_chosen(void *fdt)
+{
+   u64 start, end;
+   int node, len;
+   const fdt32_t *prop;
+
+   node = fdt_path_offset(fdt, "/chosen");
+   if (node < 0)
+      node = fdt_path_offset(fdt, "/chosen@0");
+   if (node < 0)
+      return -EINVAL;
+
+   /* Try find initrd properties */
+   prop = fdt_getprop(fdt, node, "linux,initrd-start", &len);
+   if (!prop)
+      goto parse_cmd;
+   start = fdt_read64(prop, len);
+
+   prop = fdt_getprop(fdt, node, "linux,initrd-end", &len);
+   if (!prop)
+      goto parse_cmd;
+   end = fdt_read64(prop, len);
+
+   if (start > end)
+      goto parse_cmd;
+
+   /* It is assumed that initrd is located at low 32-bit address here */
+   initrd_paddr = (u32)start;
+   initrd_size = (u32)end - initrd_paddr;
+
+parse_cmd:
+   /* Try find kernel command line */
+   prop = fdt_getprop(fdt, node, "bootargs", &len);
+   if (prop && len)
+      strncpy(cmdline_buf, (const char *)prop, CMDLINE_BUF_SZ);
+
+   return 0;
+}
+
+static int fdt_parse_memory(void *fdt)
+{
+   int node, nomem = 1;
+
+   fdt_for_each_subnode(node, fdt, 0) {
+      const char *type = fdt_getprop(fdt, node, "device_type", NULL);
+
+      /* We are scanning "memory" nodes only */
+      if (type == NULL || strcmp(type, "memory") != 0)
+         continue;
+
+      if (!fdt_node_is_enabled(fdt, node))
+         continue;
+
+      nomem = fdt_add_multiboot_mmap(fdt, node, MULTIBOOT_MEMORY_AVAILABLE);
+   }
+
+   return nomem;
+}
+
+static int fdt_parse_reserved_memory(void *fdt)
+{
+   int n;
+   u64 base, size;
+   int node, child;
+
+   /* process fdt /reserved-memory node */
+   node = fdt_path_offset(fdt, "/reserved-memory");
+   if (node < 0)
+      return 0;
+
+   fdt_for_each_subnode(child, fdt, node) {
+      const fdt32_t *reg;
+      int len;
+
+      if (!fdt_node_is_enabled(fdt, child))
+         continue;
+
+      reg = fdt_getprop(fdt, child, "reg", &len);
+      if (reg == NULL)
+         continue;
+
+      fdt_add_multiboot_mmap(fdt, child, MULTIBOOT_MEMORY_RESERVED);
+   }
+
+   /* Additionally process fdt header /memreserve/ fields */
+   for (n = 0; ; n++) {
+      fdt_get_mem_rsv(fdt, n, &base, &size);
+      if (!size)
+         break;
+
+      add_multiboot_mmap(base, size, MULTIBOOT_MEMORY_RESERVED);
+   }
+
+   return 0;
+}
+
+static int fdt_parse_framebuffer(void *fdt)
+{
+   const fdt32_t *prop;
+   int node, len, rc;
+   u64 addr, size;
+   struct simplefb_format *format;
+   char compat[] = "simple-framebuffer";
+
+   node = fdt_node_offset_by_compatible(fdt, -1, compat);
+   if (node < 0)
+      return 0;
+
+   prop = fdt_getprop(fdt, node, "width", &len);
+   if (!prop)
+      return 0;
+
+   mbi->framebuffer_width = fdt32_to_cpu(*prop);
+
+   prop = fdt_getprop(fdt, node, "height", &len);
+   if (!prop)
+      return 0;
+
+   mbi->framebuffer_height = fdt32_to_cpu(*prop);
+
+   prop = fdt_getprop(fdt, node, "stride", &len);
+   if (!prop)
+      return 0;
+
+   mbi->framebuffer_pitch = fdt32_to_cpu(*prop);
+
+   rc = fdt_get_node_addr_size(fdt, node, 0, &addr, &size);
+   if (rc)
+      return 0;
+
+   mbi->framebuffer_addr = addr;
+
+   prop = fdt_getprop(fdt, node, "format", &len);
+   if (!prop)
+      return 0;
+
+   for (int i = 0; i < ARRAY_SIZE(simplefb_formats); i++) {
+
+      if (strcmp((void *)prop, simplefb_formats[i].name))
+         continue;
+
+      format = &simplefb_formats[i];
+      mbi->framebuffer_bpp = format->bpp;
+      mbi->framebuffer_red_field_position = format->red.offset;
+      mbi->framebuffer_red_mask_size = format->red.size;
+      mbi->framebuffer_green_field_position = format->green.offset;
+      mbi->framebuffer_green_mask_size = format->green.size;
+      mbi->framebuffer_blue_field_position = format->blue.offset;
+      mbi->framebuffer_blue_mask_size = format->blue.size;
+
+      break;
+   }
+
+   mbi->framebuffer_type = MULTIBOOT_FRAMEBUFFER_TYPE_RGB;
+   mbi->flags |= MULTIBOOT_INFO_FRAMEBUFFER_INFO;
+
+   return 0;
+}
+
+/*
+ * Parse flattened device tree(fdt), translate memory layout,
+ * kernel command line and framebuffer into multiboot format used by tilck.
+ */
+multiboot_info_t *parse_fdt(void *fdt_pa)
+{
+   /* check device tree validity */
+   if (fdt_check_header(fdt_pa))
+      return NULL;
+
+   alloc_mbi();
+
+   fdt_parse_chosen(fdt_pa);
+   fdt_parse_memory(fdt_pa);
+   fdt_parse_reserved_memory(fdt_pa);
+   fdt_parse_framebuffer(fdt_pa);
+
+   setup_multiboot_info(initrd_paddr, initrd_size);
+
+   fdt_blob = PA_TO_LIN_VA(fdt_pa);
+   return mbi;
+}

--- a/kernel/arch/riscv/paging.c
+++ b/kernel/arch/riscv/paging.c
@@ -33,6 +33,19 @@ ulong linear_va_pa_offset;
 
 pdir_t *__kernel_pdir;
 
+#define EARLY_PT_NUM 4
+static page_table_t early_pt[EARLY_PT_NUM] ALIGNED_AT(PAGE_SIZE);
+
+static page_table_t *alloc_early_pt(void)
+{
+   static int early_pt_used = 0;
+
+   if (early_pt_used >= EARLY_PT_NUM)
+      return NULL;
+
+   return &early_pt[early_pt_used++];
+}
+
 bool handle_potential_cow(void *context)
 {
    NOT_IMPLEMENTED();
@@ -163,9 +176,91 @@ void map_big_page_int(pdir_t *pdir,
    NOT_IMPLEMENTED();
 }
 
+/*
+ * Used in early boot(before kmalloc initialization),
+ * only big pages are mapped.
+ */
+static inline void
+create_early_page_table(pdir_t *pdir,
+                        ulong vaddr,
+                        ulong paddr,
+                        size_t lenth,
+                        bool in_vm)
+{
+   ulong end_va = vaddr + lenth;
+   ulong pmd_paddr;
+   page_t *e;
+   page_table_t *tmpdir;
+
+   for (; vaddr < end_va;) {
+
+      tmpdir = pdir;
+
+      for (int level = RV_PAGE_LEVEL; level > 0; level--) {
+
+         e = &tmpdir->entries[PTE_INDEX(level, vaddr)];
+
+         if ((level > 1) && (!e->present)) {
+
+            if (in_vm)
+               pmd_paddr = KERNEL_VA_TO_PA((ulong)alloc_early_pt());
+            else
+               pmd_paddr = (ulong)alloc_early_pt();
+
+            e->raw = (PFN(pmd_paddr) << _PAGE_PFN_SHIFT) | PAGE_TABLE;
+
+            tmpdir = (page_table_t *)pmd_paddr;
+         } else {
+
+            tmpdir = (void *)((ulong)e->pfn << PAGE_SHIFT);
+         }
+      }
+
+      e->raw = MAKE_BIG_PAGE(paddr);
+
+      vaddr += L1_PAGE_SIZE;
+      paddr += L1_PAGE_SIZE;
+   }
+}
+
 void *init_early_mapping(ulong fdt_paddr)
 {
-   NOT_IMPLEMENTED();
+   extern char _start;
+
+   pdir_t *pgd = (void *)&page_size_buf[0];
+   ulong kernel_pa = (ulong)&_start - 0x1000;
+   ulong text_offset = ((struct linux_image_h *)(void *)&_start)->text_offset;
+   ulong base_pa = kernel_pa - text_offset;
+
+   kernel_va_pa_offset = KERNEL_BASE_VA - base_pa;
+   linear_va_pa_offset = BASE_VA - base_pa;
+
+   /* Copy the flattened device tree to 1MB below kernel's head */
+   memcpy((void *)(kernel_pa - MB), (void *)fdt_paddr, MB);
+
+   /* Kernel physical address must be aligned to L1 level big pages(2/4 MB) */
+   ASSERT(!((ulong)kernel_pa & (L1_PAGE_SIZE - 1)));
+
+   /* Identity map the first 8 MB */
+   create_early_page_table(pgd, base_pa, base_pa, EARLY_MAP_SIZE, false);
+
+   /* Map the first 8 MB also at BASE_VA */
+   create_early_page_table(pgd, BASE_VA, base_pa, EARLY_MAP_SIZE, false);
+
+   if (!KRN32_LIN_VADDR) {
+      /* Map the first 8 MB AT KERNEL_BASE_VA*/
+      create_early_page_table(pgd,
+                              KERNEL_BASE_VA,
+                              base_pa,
+                              EARLY_MAP_SIZE,
+                              false);
+   }
+
+   /* Flush entire TLB */
+   invalidate_page_hw(0);
+
+   /* Return physical addr of FDT */
+   return (void *)(kernel_pa - MB);
 }
 
 void set_pages_pat_wc(pdir_t *pdir, void *vaddr, size_t size)

--- a/kernel/arch/riscv/sbi.c
+++ b/kernel/arch/riscv/sbi.c
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#include <tilck/common/basic_defs.h>
+#include <tilck/common/utils.h>
+#include <tilck/kernel/hal.h>
+
+static bool has_srst_ext = false;
+
+struct sbiret sbi_get_spec_version(void)
+{
+   return (SBI_CALL0(SBI_BASE_EXT_ID, SBI_BASE_GET_SPEC_VERSION));
+}
+
+static long sbi_probe_extension(long eid)
+{
+   return (SBI_CALL1(SBI_BASE_EXT_ID, SBI_BASE_PROBE_EXTENSION, eid).value);
+}
+
+struct sbiret sbi_get_impl_id(void)
+{
+   return (SBI_CALL0(SBI_BASE_EXT_ID, SBI_BASE_GET_IMPL_ID));
+}
+
+struct sbiret sbi_get_impl_version(void)
+{
+   return (SBI_CALL0(SBI_BASE_EXT_ID, SBI_BASE_GET_IMPL_VERSION));
+}
+
+struct sbiret sbi_get_mvendorid(void)
+{
+   return (SBI_CALL0(SBI_BASE_EXT_ID, SBI_BASE_GET_MVENDORID));
+}
+
+struct sbiret sbi_get_marchid(void)
+{
+   return (SBI_CALL0(SBI_BASE_EXT_ID, SBI_BASE_GET_MARCHID));
+}
+
+struct sbiret sbi_get_mimpid(void)
+{
+   return (SBI_CALL0(SBI_BASE_EXT_ID, SBI_BASE_GET_MIMPID));
+}
+
+void sbi_shutdown(void)
+{
+   SBI_CALL0(SBI_SHUTDOWN, 0);
+}
+
+void sbi_system_reset(u32 type, u32 reason)
+{
+   if (has_srst_ext)
+      SBI_CALL2(SBI_SRST_EXT_ID,
+                SBI_SRST_SYSTEM_RESET,
+                type, reason);
+
+   sbi_shutdown();
+}
+
+void sbi_init(void)
+{
+   if (sbi_get_spec_version().error)
+      return; // use legacy extensions
+
+   if (sbi_probe_extension(SBI_SRST_EXT_ID) != 0)
+      has_srst_ext = true;
+}

--- a/kernel/arch/riscv/start.S
+++ b/kernel/arch/riscv/start.S
@@ -16,6 +16,7 @@
 
 .section .text.start
 .global _start
+.global _boot_cpu_hartid
 
 #define RISCV_IMAGE_MAGIC   "RISCV\0\0\0"
 #define RISCV_IMAGE_MAGIC2   "RSC\x05"
@@ -64,6 +65,92 @@ _start_kernel:
    csrw CSR_SIP, zero
    csrw CSR_SSCRATCH, zero
 
-   j _start_kernel
+   /* Disable FPU */
+   li t0, SR_FS
+   csrc sstatus, t0
+
+   /* The first hart to get the lottery continues to execute */
+   lla   a6, _boot_lottery
+   li   a7, 1
+   amoadd.w a6, a7, (a6)
+   bnez   a6, _wait_forerver
+
+   /* clear bss */
+   la a3, __bss_start
+   la a4, __bss_stop
+   ble a4, a3, clear_bss_done
+clear_bss:
+   REG_S zero, (a3)
+   add a3, a3, RISCV_SZPTR
+   blt a3, a4, clear_bss
+clear_bss_done:
+
+   /* Setup temporary trap handler */
+   lla   a5, _early_fault
+   csrw  CSR_STVEC, a5
+
+   mv s0, a0   /* Save hart ID */
+   mv s1, a1   /* Save DTB physical address */
+   la a2, _boot_cpu_hartid
+   REG_S a0, (a2)
+
+   la sp, kernel_initial_stack + ASM_KERNEL_STACK_SZ
+   call sbi_init
+
+   mv a0, s1
+   call init_early_mapping
+
+   call parse_fdt
+   mv s2, a0   /* Save multiboot info structure physical address */
+
+   la a0, page_size_buf
+   li a1, SATP_MODE
+   srl a0, a0, 12
+   or a0, a0, a1
+
+   la a1, kernel_va_pa_offset
+   REG_L a1, (a1)
+
+   /* Enable paging */
+   sfence.vma
+   csrw CSR_SATP, a0
+
+   /* Calculate return address */
+   la ra, .next_step
+   add ra, ra, a1
+
+   /* Return to .next_step using high virtual address */
+   ret
+
+.next_step:
+
+   call early_get_cpu_features
+
+   /* Enable access to user memory */
+   li t0, SR_SUM
+   csrs CSR_SSTATUS, t0
+
+   la sp, kernel_initial_stack + ASM_KERNEL_STACK_SZ
+   mv a1, s2   /* 2st argument: multiboot information structure */
+   li a0, MULTIBOOT_BOOTLOADER_MAGIC   /* 1nd argument: multiboot magic */
+   call kmain
+
+.align 2
+_wait_forerver:
+   /* We lack SMP support, so park this hart */
+   wfi
+   j _wait_forerver
+
+.align 3
+_early_fault:
+   wfi
+   j   _early_fault
 
 END_FUNC(_start)
+
+.section .data
+.align 3
+_boot_lottery:
+   RISCV_PTR   0
+_boot_cpu_hartid:
+   .word   0


### PR DESCRIPTION
Hi @vvaltchev 

riscv init code before entering kmain():
1. setup early mapping;
2. get memory map and simple-fb param from fdt; (Note: The official u-boot does not implement simple-fb on qemu-virt yet, but as far as I know, some riscv chip vendors have released their own u-boot which already has implementations of simple-fb! (e.g. Allwinner D1、Sophgo riscv series))
3. enable virtual address;
4. get cpu features from fdt;

