### PR TITLE
Minor coding style fixes in the RISCV64 code

### DIFF
--- a/include/3rd_party/fdt_helper.h
+++ b/include/3rd_party/fdt_helper.h
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: BSD-2-Clause
+
 /*
  * fdt_helper.h - Flat Device Tree parsing helper routines
  * Implement helper routines to parse FDT nodes on top of
@@ -44,3 +45,4 @@ int fdt_get_node_addr_size_by_name(void *fdt, int node, const char *name,
 bool fdt_node_is_enabled(void *fdt, int nodeoff);
 
 #endif /* __FDT_HELPER_H__ */
+

--- a/include/tilck/kernel/arch/riscv/arch_ints.h
+++ b/include/tilck/kernel/arch/riscv/arch_ints.h
@@ -29,3 +29,4 @@ static ALWAYS_INLINE bool is_fault(int int_num)
 {
    return IN_RANGE(int_num, 0, 32);
 }
+

--- a/include/tilck/kernel/arch/riscv/arch_utils.h
+++ b/include/tilck/kernel/arch/riscv/arch_utils.h
@@ -110,3 +110,4 @@ static ALWAYS_INLINE void *fdt_get_address(void)
    extern void * fdt_blob;
    return fdt_blob;
 }
+

--- a/include/tilck/kernel/arch/riscv/asm_defs.h
+++ b/include/tilck/kernel/arch/riscv/asm_defs.h
@@ -53,3 +53,4 @@
 #define END_FUNC(x) .size x, .-(x)
 
 #endif
+

--- a/include/tilck/kernel/arch/riscv/cpu_features.h
+++ b/include/tilck/kernel/arch/riscv/cpu_features.h
@@ -55,3 +55,4 @@ extern volatile struct riscv_cpu_features riscv_cpu_features;
 
 void get_cpu_features(void);
 void dump_riscv_features(void);
+

--- a/include/tilck/kernel/arch/riscv/fpu_memcpy.h
+++ b/include/tilck/kernel/arch/riscv/fpu_memcpy.h
@@ -5,9 +5,9 @@
 #include <tilck/common/string_util.h>
 
 #ifdef __FPU_MEMCPY_C__
-#define EXTERN extern
+   #define EXTERN extern
 #else
-#define EXTERN
+   #define EXTERN
 #endif
 
 
@@ -56,3 +56,4 @@ fpu_cpy_single_256_nt_read(void *dest, const void *src)
 
 
 void init_fpu_memcpy(void);
+

--- a/include/tilck/kernel/arch/riscv/ioremap.h
+++ b/include/tilck/kernel/arch/riscv/ioremap.h
@@ -6,3 +6,4 @@
 /* The size pointer returns the actual allocated size */
 void *ioremap(ulong paddr, size_t size);
 void iounmap(void *vaddr);
+

--- a/include/tilck/kernel/arch/riscv/mmio.h
+++ b/include/tilck/kernel/arch/riscv/mmio.h
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 
 #pragma once
-
 #include <tilck/common/basic_defs.h>
 
 #define mb()    asmVolatile("fence iorw, iorw" : : : "memory")
@@ -71,3 +70,4 @@ mmio_writeq(u64 val, volatile void *addr)
    wmb();
    *(volatile u64 *)addr = val;
 }
+

--- a/include/tilck/kernel/arch/riscv/sbi.h
+++ b/include/tilck/kernel/arch/riscv/sbi.h
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 
 #pragma once
-
 #include <tilck/common/basic_defs.h>
 
 /* Standard SBI Errors */
@@ -108,3 +107,4 @@ struct sbiret sbi_get_marchid(void);
 struct sbiret sbi_get_mimpid(void);
 void sbi_system_reset(u32 type, u32 reason);
 void sbi_shutdown(void);
+

--- a/kernel/arch/riscv/cpu_features.c
+++ b/kernel/arch/riscv/cpu_features.c
@@ -98,8 +98,10 @@ fdt_parse_hart_id(void *fdt, int cpu_offset, u32 *hartid)
       return -1;
 
    prop = fdt_getprop(fdt, cpu_offset, "device_type", &len);
+
    if (!prop || !len)
       return -1;
+
    if (strncmp (prop, "cpu", strlen ("cpu")))
       return -1;
 
@@ -135,7 +137,7 @@ static int fdt_parse_isa_extensions(void *fdt)
       prop = fdt_getprop(fdt, cpu_node, "device_type", NULL);
 
       if (prop &&
-         !strcmp((void *)prop, "cpu") &&
+          !strcmp((void *)prop, "cpu") &&
           hart_id == get_boothartid())
       {
          prop = fdt_getprop(fdt, cpu_node, "riscv,isa", &len);
@@ -167,7 +169,7 @@ static bool isa_ext_string_match(const char *string)
 
    for (char *ptr = buf; ptr < end; ptr += strlen(ptr) + 1) {
 
-      if (strcmp(string, ptr) == 0)
+      if (!strcmp(string, ptr))
          return true;
    }
 
@@ -203,7 +205,7 @@ static bool isa_ext_string_match(const char *string)
          len = (chr ? chr : end) - ptr;
          if (strncmp(string, ptr, len) == 0)
             return true;
-   }
+      }
    }
 
    return false;
@@ -217,7 +219,6 @@ static bool isa_ext_string_match(const char *string)
 void early_get_cpu_features(void)
 {
    struct riscv_cpu_features *f = (void *)&riscv_cpu_features;
-
    bool *flags = (bool *)&f->isa_exts;
 
    if (sbi_get_spec_version().error) {
@@ -226,6 +227,7 @@ void early_get_cpu_features(void)
       f->vendor_id = 0;
       f->arch_id = 0;
       f->imp_id = 0;
+
    } else {
 
       f->vendor_id = sbi_get_mvendorid().value;
@@ -235,7 +237,6 @@ void early_get_cpu_features(void)
 
    fdt_parse_model(fdt_get_address());
    fdt_parse_isa_extensions(fdt_get_address());
-
    bzero(&f->isa_exts, sizeof(f->isa_exts));
 
    for (u32 i = 0; i < ARRAY_SIZE(isa_exts_names); i++) {

--- a/kernel/arch/riscv/early_fdt.c
+++ b/kernel/arch/riscv/early_fdt.c
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
+
 #include <tilck/common/basic_defs.h>
 #include <tilck/common/boot.h>
 #include <tilck/common/string_util.h>
@@ -14,13 +15,13 @@
 #define CMDLINE_BUF_SZ 1024
 
 struct simplefb_bitfield {
-   u8 offset;   /* beginning of bitfield */
-   u8 size;       /* length of bitfield */
+   u8 offset;                       /* beginning of bitfield */
+   u8 size;                         /* length of bitfield */
 };
 
 struct simplefb_format {
    const char *name;
-   u8 bpp;  /* bits per pixel */
+   u8 bpp;                          /* bits per pixel */
    struct simplefb_bitfield red;
    struct simplefb_bitfield green;
    struct simplefb_bitfield blue;
@@ -83,7 +84,6 @@ add_multiboot_mmap(u64 addr, u64 size, u32 type)
       mmmap--;
 
    mmmap_count++;
-
    bzero(mmmap, sizeof(multiboot_memory_map_t));
 
    if (addr < mbi->mem_lower * KB)
@@ -176,7 +176,6 @@ fdt_add_multiboot_mmap(void *fdt, int node, u32 type)
    while (fdt_get_node_linux_usable_memory(fdt, node, index,
                                            &addr, &size) == 0)
    {
-
       if (size == 0)
          continue;
 
@@ -192,7 +191,6 @@ fdt_add_multiboot_mmap(void *fdt, int node, u32 type)
    while (fdt_get_node_addr_size(fdt, node,
                                  index, &addr, &size) == 0)
    {
-
       if (size == 0)
          continue;
 
@@ -232,11 +230,13 @@ static int fdt_parse_chosen(void *fdt)
    prop = fdt_getprop(fdt, node, "linux,initrd-start", &len);
    if (!prop)
       goto parse_cmd;
+
    start = fdt_read64(prop, len);
 
    prop = fdt_getprop(fdt, node, "linux,initrd-end", &len);
    if (!prop)
       goto parse_cmd;
+
    end = fdt_read64(prop, len);
 
    if (start > end)
@@ -260,6 +260,7 @@ static int fdt_parse_memory(void *fdt)
    int node, nomem = 1;
 
    fdt_for_each_subnode(node, fdt, 0) {
+
       const char *type = fdt_getprop(fdt, node, "device_type", NULL);
 
       /* We are scanning "memory" nodes only */
@@ -277,9 +278,8 @@ static int fdt_parse_memory(void *fdt)
 
 static int fdt_parse_reserved_memory(void *fdt)
 {
-   int n;
    u64 base, size;
-   int node, child;
+   int n, node, child;
 
    /* process fdt /reserved-memory node */
    node = fdt_path_offset(fdt, "/reserved-memory");
@@ -365,13 +365,11 @@ static int fdt_parse_framebuffer(void *fdt)
       mbi->framebuffer_green_mask_size = format->green.size;
       mbi->framebuffer_blue_field_position = format->blue.offset;
       mbi->framebuffer_blue_mask_size = format->blue.size;
-
       break;
    }
 
    mbi->framebuffer_type = MULTIBOOT_FRAMEBUFFER_TYPE_RGB;
    mbi->flags |= MULTIBOOT_INFO_FRAMEBUFFER_INFO;
-
    return 0;
 }
 

--- a/kernel/arch/riscv/fault.c
+++ b/kernel/arch/riscv/fault.c
@@ -63,3 +63,4 @@ void on_first_pdir_update(void)
 {
    return;
 }
+

--- a/kernel/arch/riscv/fault_resumable.S
+++ b/kernel/arch/riscv/fault_resumable.S
@@ -14,3 +14,4 @@ FUNC(fault_resumable_call):
    ret
 
 END_FUNC(fault_resumable_call)
+

--- a/kernel/arch/riscv/fpu.S
+++ b/kernel/arch/riscv/fpu.S
@@ -24,3 +24,4 @@ FUNC(asm_restore_fpu):
    ret
 
 END_FUNC(asm_restore_fpu)
+

--- a/kernel/arch/riscv/fpu_memcpy.c
+++ b/kernel/arch/riscv/fpu_memcpy.c
@@ -39,3 +39,4 @@ memcpy_single_256_failsafe(void *dest, const void *src)
 {
    memcpy32(dest, src, 8);
 }
+

--- a/kernel/arch/riscv/irq.c
+++ b/kernel/arch/riscv/irq.c
@@ -56,3 +56,4 @@ void init_irq_handling(void)
 {
    NOT_IMPLEMENTED();
 }
+

--- a/kernel/arch/riscv/misc.S
+++ b/kernel/arch/riscv/misc.S
@@ -44,3 +44,4 @@ FUNC(asm_do_bogomips_loop):
    ret
 
 END_FUNC(asm_do_bogomips_loop)
+

--- a/kernel/arch/riscv/misc.c
+++ b/kernel/arch/riscv/misc.c
@@ -23,3 +23,4 @@ NORETURN void reboot(void)
 {
    NOT_IMPLEMENTED();
 }
+

--- a/kernel/arch/riscv/mmap.c
+++ b/kernel/arch/riscv/mmap.c
@@ -19,3 +19,4 @@ bool arch_add_final_mem_regions()
 {
    NOT_IMPLEMENTED();
 }
+

--- a/kernel/arch/riscv/paging.c
+++ b/kernel/arch/riscv/paging.c
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
+
 #include <tilck_gen_headers/config_mm.h>
 
 #include <tilck/common/basic_defs.h>
@@ -299,3 +300,4 @@ virtual_write_unsafe(pdir_t *pdir, void *extern_va, void *src, size_t len)
 {
    NOT_IMPLEMENTED();
 }
+

--- a/kernel/arch/riscv/paging_generic.c
+++ b/kernel/arch/riscv/paging_generic.c
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
+
 #include <tilck_gen_headers/config_mm.h>
 #include <tilck_gen_headers/mod_fb.h>
 
@@ -103,3 +104,4 @@ void handle_page_fault(regs_t *r)
 {
    NOT_IMPLEMENTED();
 }
+

--- a/kernel/arch/riscv/paging_int.h
+++ b/kernel/arch/riscv/paging_int.h
@@ -62,30 +62,32 @@
 
 #if __riscv_xlen == 32
 
-/* Size of region mapped by a page global directory */
-#define PGDIR_SHIFT     22
-#define PGDIR_SIZE      (1UL << PGDIR_SHIFT)
+   /* Size of region mapped by a page global directory */
+   #define PGDIR_SHIFT     22
+   #define PGDIR_SIZE      (1UL << PGDIR_SHIFT)
 
-#define L0_PAGE_SHIFT       PAGE_SHIFT
-#define L1_PAGE_SHIFT       PGDIR_SHIFT
-#define L1_PAGE_SIZE        PGDIR_SIZE
-#define RV_PAGE_LEVEL        1
+   #define L0_PAGE_SHIFT   PAGE_SHIFT
+   #define L1_PAGE_SHIFT   PGDIR_SHIFT
+   #define L1_PAGE_SIZE    PGDIR_SIZE
+   #define RV_PAGE_LEVEL   1
 
 #else
 
-#define PGDIR_SHIFT     30
-/* Size of region mapped by a page global directory */
-#define PGDIR_SIZE      (1UL << PGDIR_SHIFT)
-#define PMD_SHIFT       21
-/* Size of region mapped by a page middle directory */
-#define PMD_SIZE        (1UL << PMD_SHIFT)
+   #define PGDIR_SHIFT     30
 
-#define L0_PAGE_SHIFT       PAGE_SHIFT
-#define L1_PAGE_SHIFT       PMD_SHIFT
-#define L1_PAGE_SIZE        PMD_SIZE
-#define L2_PAGE_SHIFT       PGDIR_SHIFT
-#define L2_PAGE_SIZE        PGDIR_SIZE
-#define RV_PAGE_LEVEL        2
+   /* Size of region mapped by a page global directory */
+   #define PGDIR_SIZE      (1UL << PGDIR_SHIFT)
+   #define PMD_SHIFT       21
+
+/* Size of region mapped by a page middle directory */
+   #define PMD_SIZE        (1UL << PMD_SHIFT)
+
+   #define L0_PAGE_SHIFT   PAGE_SHIFT
+   #define L1_PAGE_SHIFT   PMD_SHIFT
+   #define L1_PAGE_SIZE    PMD_SIZE
+   #define L2_PAGE_SHIFT   PGDIR_SHIFT
+   #define L2_PAGE_SIZE    PGDIR_SIZE
+   #define RV_PAGE_LEVEL   2
 
 #endif
 
@@ -96,12 +98,13 @@
 #define PFN(x) ((x) >> PAGE_SHIFT)
 
 /* Extract the each level page table indices from a virtual address */
-#define PTE_SHIFT(level)   (PAGE_SHIFT+(9*(level)))
-#define PTE_INDEX(level, vaddr)  ((((ulong)(vaddr)) >>   \
-                                  PTE_SHIFT(level)) & (PTRS_PER_PT - 1))
+#define PTE_SHIFT(level)         (PAGE_SHIFT + (9*(level)))
 
-#define MAKE_BIG_PAGE(paddr) (_PAGE_BASE | _PAGE_WRITE | _PAGE_GLOBAL \
-                        | (PFN(paddr) << _PAGE_PFN_SHIFT))
+#define PTE_INDEX(level, vaddr)  \
+   ((((ulong)(vaddr)) >> PTE_SHIFT(level)) & (PTRS_PER_PT - 1))
+
+#define MAKE_BIG_PAGE(paddr) \
+   (_PAGE_BASE | _PAGE_WRITE | _PAGE_GLOBAL | (PFN(paddr) << _PAGE_PFN_SHIFT))
 
 #define BASE_VADDR_PD_IDX                (USERMODE_VADDR_END >> PGDIR_SHIFT)
 
@@ -144,3 +147,4 @@ void map_big_page_int(pdir_t *pdir,
                       u32 flags);
 
 void set_pages_io(pdir_t *pdir, void *vaddr, size_t size);
+

--- a/kernel/arch/riscv/panic.c
+++ b/kernel/arch/riscv/panic.c
@@ -38,3 +38,4 @@ NORETURN void panic(const char *fmt, ...)
 {
    NOT_IMPLEMENTED();
 }
+

--- a/kernel/arch/riscv/process.c
+++ b/kernel/arch/riscv/process.c
@@ -164,3 +164,4 @@ void handle_bus_fault_int(regs_t *r, const char *fault_name)
 {
    NOT_IMPLEMENTED();
 }
+

--- a/kernel/arch/riscv/sbi.c
+++ b/kernel/arch/riscv/sbi.c
@@ -64,3 +64,4 @@ void sbi_init(void)
    if (sbi_probe_extension(SBI_SRST_EXT_ID) != 0)
       has_srst_ext = true;
 }
+

--- a/kernel/arch/riscv/start.S
+++ b/kernel/arch/riscv/start.S
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-
 #define ASM_FILE 1
 
 #include <tilck_gen_headers/config_global.h>
@@ -154,3 +153,4 @@ _boot_lottery:
    RISCV_PTR   0
 _boot_cpu_hartid:
    .word   0
+

--- a/kernel/arch/riscv/timer.c
+++ b/kernel/arch/riscv/timer.c
@@ -19,3 +19,4 @@ u32 hw_timer_setup(u32 interval)
 {
    NOT_IMPLEMENTED();
 }
+

--- a/kernel/arch/riscv/trap_entry.S
+++ b/kernel/arch/riscv/trap_entry.S
@@ -22,3 +22,4 @@ FUNC(context_switch):
    ret
 
 END_FUNC(context_switch)
+

--- a/kernel/arch/riscv/vdso.S
+++ b/kernel/arch/riscv/vdso.S
@@ -40,3 +40,4 @@ RISCV_PTR USER_VDSO_VADDR + (.post_sig_handler - vdso_begin)
 .global pause_trampoline_user_vaddr
 pause_trampoline_user_vaddr:
 RISCV_PTR USER_VDSO_VADDR + (.pause_trampoline - vdso_begin)
+

--- a/kernel/arch/riscv64/CMakeLists.txt
+++ b/kernel/arch/riscv64/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-2-Clause
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.22)
 
 # Remove -rdynamic
 set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)
@@ -173,3 +173,4 @@ add_custom_target(
     DEPENDS
         ${KERNEL_FILE}
 )
+

--- a/kernel/arch/riscv64/CMakeLists.txt
+++ b/kernel/arch/riscv64/CMakeLists.txt
@@ -21,11 +21,6 @@ list(
    -fno-exceptions
    -fno-stack-protector
    -fno-asynchronous-unwind-tables
-
-   # Allow easier disassembly debugging
-   # -mpush-args
-   # -mno-accumulate-outgoing-args
-   # -mno-stack-arg-probe
 )
 
 if (KERNEL_GCOV)
@@ -73,7 +68,7 @@ set(
 
    -Wl,--build-id=none
    -Wl,--script=${KERNEL_SCRIPT}
-   -Wl,-Map=${CMAKE_SOURCE_DIR}/tilck.map
+   -Wl,-Map=${CMAKE_BINARY_DIR}/tilck.map
 )
 
 JOIN("${KERNEL_LINK_FLAGS_LIST}" ${SPACE} KERNEL_LINK_FLAGS)

--- a/kernel/arch/riscv64/arch_syscalls.c
+++ b/kernel/arch/riscv64/arch_syscalls.c
@@ -38,3 +38,4 @@ void init_syscall_interfaces(void)
 {
    /* do nothing */
 }
+


### PR DESCRIPTION
@aenrbes I made some minor coding style fixing (formatting, whitespace etc.) to the RISCV64 code. I preferred making those fixes myself to avoid bothering you too many with very "little value" comments.

One change however is non-cosmetic: I moved the `tilck.map` to the build directory `${CMAKE_BINARY_DIR}` because it was written to the root source directory: all the generated files should go in `${CMAKE_BINARY_DIR}` because that could be anywhere. Supporting out-of-tree builds is very important.

I believe this small change shouldn't cause any issues as I didn't see any other references to `tilck.map` but I guess you might have some other code relying on that.