### PR TITLE
[riscv64] Implement exception handling and panic

### DIFF
--- a/include/tilck/kernel/arch/riscv/asm_defs.h
+++ b/include/tilck/kernel/arch/riscv/asm_defs.h
@@ -52,5 +52,163 @@
 #define FUNC(x) .type x, @function; x
 #define END_FUNC(x) .size x, .-(x)
 
+.macro save_fp_ra
+   addi sp, sp, -(RISCV_SZPTR * 4)
+   REG_S ra, 3 * RISCV_SZPTR(sp)
+   REG_S s0, 2 * RISCV_SZPTR(sp)
+   addi s0, sp, (RISCV_SZPTR * 4)
+.endm
+
+.macro restore_fp_ra
+   REG_L ra, 3 * RISCV_SZPTR(sp)
+   REG_L s0, 2 * RISCV_SZPTR(sp)
+   addi  sp, sp, (RISCV_SZPTR * 4)
+.endm
+
+.macro save_callee_regs
+
+   mv t0, sp
+   addi sp, sp, -SIZEOF_REGS
+
+   REG_S ra,   1 * RISCV_SZPTR(sp)
+   REG_S t0,   2 * RISCV_SZPTR(sp)
+   REG_S s0,   8 * RISCV_SZPTR(sp)
+   REG_S s1,   9 * RISCV_SZPTR(sp)
+   REG_S s2,  18 * RISCV_SZPTR(sp)
+   REG_S s3,  19 * RISCV_SZPTR(sp)
+   REG_S s4,  20 * RISCV_SZPTR(sp)
+   REG_S s5,  21 * RISCV_SZPTR(sp)
+   REG_S s6,  22 * RISCV_SZPTR(sp)
+   REG_S s7,  23 * RISCV_SZPTR(sp)
+   REG_S s8,  24 * RISCV_SZPTR(sp)
+   REG_S s9,  25 * RISCV_SZPTR(sp)
+   REG_S s10, 26 * RISCV_SZPTR(sp)
+   REG_S s11, 27 * RISCV_SZPTR(sp)
+
+   csrr s1, sstatus
+   REG_S s1, 33 * RISCV_SZPTR(sp)
+
+.endm
+
+.macro resume_callee_regs
+
+   REG_L s1, 33 * RISCV_SZPTR(sp)
+   csrw sstatus, s1
+
+   REG_L ra,   1 * RISCV_SZPTR(sp)
+   REG_L t0,   2 * RISCV_SZPTR(sp)
+   REG_L s0,   8 * RISCV_SZPTR(sp)
+   REG_L s1,   9 * RISCV_SZPTR(sp)
+   REG_L s2,  18 * RISCV_SZPTR(sp)
+   REG_L s3,  19 * RISCV_SZPTR(sp)
+   REG_L s4,  20 * RISCV_SZPTR(sp)
+   REG_L s5,  21 * RISCV_SZPTR(sp)
+   REG_L s6,  22 * RISCV_SZPTR(sp)
+   REG_L s7,  23 * RISCV_SZPTR(sp)
+   REG_L s8,  24 * RISCV_SZPTR(sp)
+   REG_L s9,  25 * RISCV_SZPTR(sp)
+   REG_L s10, 26 * RISCV_SZPTR(sp)
+   REG_L s11, 27 * RISCV_SZPTR(sp)
+
+   REG_L sp,   2 * RISCV_SZPTR(sp)
+
+.endm
+
+.macro save_all_regs
+
+   addi sp, sp, -SIZEOF_REGS
+
+   REG_S x1,   1 * RISCV_SZPTR(sp)
+
+   REG_S x3,   3 * RISCV_SZPTR(sp)
+   REG_S x4,   4 * RISCV_SZPTR(sp)
+   REG_S x5,   5 * RISCV_SZPTR(sp)
+   REG_S x6,   6 * RISCV_SZPTR(sp)
+   REG_S x7,   7 * RISCV_SZPTR(sp)
+   REG_S x8,   8 * RISCV_SZPTR(sp)
+   REG_S x9,   9 * RISCV_SZPTR(sp)
+   REG_S x10, 10 * RISCV_SZPTR(sp)
+   REG_S x11, 11 * RISCV_SZPTR(sp)
+   REG_S x12, 12 * RISCV_SZPTR(sp)
+   REG_S x13, 13 * RISCV_SZPTR(sp)
+   REG_S x14, 14 * RISCV_SZPTR(sp)
+   REG_S x15, 15 * RISCV_SZPTR(sp)
+   REG_S x16, 16 * RISCV_SZPTR(sp)
+   REG_S x17, 17 * RISCV_SZPTR(sp)
+   REG_S x18, 18 * RISCV_SZPTR(sp)
+   REG_S x19, 19 * RISCV_SZPTR(sp)
+   REG_S x20, 20 * RISCV_SZPTR(sp)
+   REG_S x21, 21 * RISCV_SZPTR(sp)
+   REG_S x22, 22 * RISCV_SZPTR(sp)
+   REG_S x23, 23 * RISCV_SZPTR(sp)
+   REG_S x24, 24 * RISCV_SZPTR(sp)
+   REG_S x25, 25 * RISCV_SZPTR(sp)
+   REG_S x26, 26 * RISCV_SZPTR(sp)
+   REG_S x27, 27 * RISCV_SZPTR(sp)
+   REG_S x28, 28 * RISCV_SZPTR(sp)
+   REG_S x29, 29 * RISCV_SZPTR(sp)
+   REG_S x30, 30 * RISCV_SZPTR(sp)
+   REG_S x31, 31 * RISCV_SZPTR(sp)
+
+   csrr s0, sepc
+   csrr s1, sstatus
+   csrr s2, stval
+   csrr s3, scause
+   csrr s4, sscratch
+
+   REG_S s0, 32 * RISCV_SZPTR(sp)
+   REG_S s1, 33 * RISCV_SZPTR(sp)
+   REG_S s2, 34 * RISCV_SZPTR(sp)
+   REG_S s3, 35 * RISCV_SZPTR(sp)
+   REG_S s4, 38 * RISCV_SZPTR(sp)
+
+   addi s0, sp, SIZEOF_REGS
+   REG_S s0,  2 * RISCV_SZPTR(sp)
+
+.endm
+
+.macro resume_all_regs
+
+   REG_L s0, 32 * RISCV_SZPTR(sp)
+   REG_L s1, 33 * RISCV_SZPTR(sp)
+   andi s1, s1, ~SR_SIE //The interrupt must remain closed until sret
+   csrw sepc, s0
+   csrw sstatus, s1
+
+   REG_L x1,   1 * RISCV_SZPTR(sp)
+
+   REG_L x3,   3 * RISCV_SZPTR(sp)
+   REG_L x4,   4 * RISCV_SZPTR(sp)
+   REG_L x5,   5 * RISCV_SZPTR(sp)
+   REG_L x6,   6 * RISCV_SZPTR(sp)
+   REG_L x7,   7 * RISCV_SZPTR(sp)
+   REG_L x8,   8 * RISCV_SZPTR(sp)
+   REG_L x9,   9 * RISCV_SZPTR(sp)
+   REG_L x10, 10 * RISCV_SZPTR(sp)
+   REG_L x11, 11 * RISCV_SZPTR(sp)
+   REG_L x12, 12 * RISCV_SZPTR(sp)
+   REG_L x13, 13 * RISCV_SZPTR(sp)
+   REG_L x14, 14 * RISCV_SZPTR(sp)
+   REG_L x15, 15 * RISCV_SZPTR(sp)
+   REG_L x16, 16 * RISCV_SZPTR(sp)
+   REG_L x17, 17 * RISCV_SZPTR(sp)
+   REG_L x18, 18 * RISCV_SZPTR(sp)
+   REG_L x19, 19 * RISCV_SZPTR(sp)
+   REG_L x20, 20 * RISCV_SZPTR(sp)
+   REG_L x21, 21 * RISCV_SZPTR(sp)
+   REG_L x22, 22 * RISCV_SZPTR(sp)
+   REG_L x23, 23 * RISCV_SZPTR(sp)
+   REG_L x24, 24 * RISCV_SZPTR(sp)
+   REG_L x25, 25 * RISCV_SZPTR(sp)
+   REG_L x26, 26 * RISCV_SZPTR(sp)
+   REG_L x27, 27 * RISCV_SZPTR(sp)
+   REG_L x28, 28 * RISCV_SZPTR(sp)
+   REG_L x29, 29 * RISCV_SZPTR(sp)
+   REG_L x30, 30 * RISCV_SZPTR(sp)
+   REG_L x31, 31 * RISCV_SZPTR(sp)
+
+   REG_L x2, 2 * RISCV_SZPTR(sp)
+.endm
+
 #endif
 

--- a/kernel/arch/riscv/debug.c
+++ b/kernel/arch/riscv/debug.c
@@ -13,27 +13,192 @@
 
 #include <elf.h>
 
+static bool fp_is_valid(ulong fp, ulong sp)
+{
+   ulong low = sp + 2 * sizeof(void *);
+   ulong high = (sp + (KERNEL_STACK_SIZE - 1)) & ~(KERNEL_STACK_SIZE - 1);
+
+   if (!fp || fp < low || fp > high || fp & 0x7)
+      return false;
+   else
+      return true;
+}
+
+static size_t
+stackwalk_riscv(void **frames,
+            size_t count,
+            void *fp,
+            pdir_t *pdir)
+{
+   bool curr_pdir = false;
+   void *retAddr;
+   size_t i;
+   ulong old_fp;
+
+   if (!fp) {
+      fp = __builtin_frame_address(0);
+   }
+
+   if (!pdir) {
+      pdir = get_curr_pdir();
+      curr_pdir = true;
+   }
+
+   for (i = 0; i < count; i++) {
+
+      old_fp = (ulong)fp;
+
+      if ((ulong)fp < BASE_VA)
+         break;
+
+      if (curr_pdir) {
+
+         retAddr = *((void **)fp - 1);
+         fp = *((void **)fp - 2);
+
+      } else {
+
+         if (virtual_read(pdir, (void **)fp - 1,
+                          &retAddr, sizeof(retAddr)) < 0)
+            break;
+
+         if (virtual_read(pdir, (void **)fp - 2,
+                          &fp, sizeof(fp)) < 0)
+            break;
+      }
+
+      if (!fp_is_valid((ulong)fp, old_fp)) {
+
+         /*
+          * In cases where the compiler lacks the option
+          * -fno-omit-leaf-frame-pointer, in the leaf function,
+          * fp is saved in the position where ra is in non-leaf case.
+          */
+         if (fp_is_valid((ulong)retAddr, old_fp)) {
+
+            fp = retAddr;
+            continue;
+         }
+
+         break;
+      }
+
+      frames[i] = retAddr;
+   }
+
+   return i;
+}
+
 void dump_stacktrace(void *ebp, pdir_t *pdir)
 {
-   NOT_IMPLEMENTED();
+   void *frames[32] = {0};
+   size_t c = stackwalk32(frames, ARRAY_SIZE(frames), ebp, pdir);
+
+   printk("Stacktrace (%lu frames):\n", c);
+
+   for (size_t i = 0; i < c; i++) {
+
+      long off = 0;
+      u32 sym_size;
+      ulong va = (ulong)frames[i];
+      const char *sym_name;
+
+      sym_name = find_sym_at_addr(va, &off, &sym_size);
+
+      if (sym_name && off == 0) {
+
+         /*
+          * Since we're resolving return addresses, not addresses, we have to
+          * keep in mind that offset == 0 means that the next instruction after
+          * a call was the beginning of a new function. This happens when a
+          * function calls a NORETURN function like panic(). In this case, in
+          * order to correctly resolve the caller's function name, we need to
+          * decrease the vaddr when searching for the symbol name.
+          */
+
+         sym_name = find_sym_at_addr(va - 1, &off, &sym_size);
+
+         /*
+          * Now we have to increase the offset value because in the backtrace
+          * the original vaddr will be shown. [We passed "va-1" instead of "va"
+          * because we wanted the previous function, now we have to adjust the
+          * offset.]
+          */
+
+         off++;
+      }
+
+      printk("[%p] %s + 0X%lx\n", TO_PTR(va), sym_name ? sym_name : "???", off);
+   }
+
+   printk("\n");
 }
 
 void dump_sstatus(ulong sstatus)
 {
-   NOT_IMPLEMENTED();
+   printk("sstatus: %p [ %s%s%s%s%s]\n",
+          TO_PTR(sstatus),
+          sstatus & SR_SIE        ? "SIE " : "",
+          sstatus & SR_SPIE       ? "SPIE " : "",
+          sstatus & SR_SPP        ? "SPP " : "",
+          sstatus & SR_SUM        ? "SUM " : "",
+          sstatus & SR_FS         ? "FS " : "");
 }
 
 void dump_regs(regs_t *r)
 {
-   NOT_IMPLEMENTED();
+   dump_sstatus(r->sstatus);
+
+   printk("ra: %p, sp: %p, gp: %p, tp: %p\n",
+          TO_PTR(r->ra), TO_PTR(r->sp), TO_PTR(r->gp), TO_PTR(r->tp));
+
+   printk("t0: %p, t1: %p, t2: %p, s0: %p\n",
+          TO_PTR(r->t0), TO_PTR(r->t1), TO_PTR(r->t2), TO_PTR(r->s0));
+
+   printk("s1: %p, a0: %p, a1: %p, a2: %p\n",
+          TO_PTR(r->s1), TO_PTR(r->a0), TO_PTR(r->a1), TO_PTR(r->a2));
+
+   printk("a3: %p, a4: %p, a5: %p, a6: %p\n",
+          TO_PTR(r->a3), TO_PTR(r->a4), TO_PTR(r->a5), TO_PTR(r->a6));
+
+   printk("a7: %p, s2: %p, s3: %p, s4: %p\n",
+          TO_PTR(r->a7), TO_PTR(r->s2), TO_PTR(r->s3), TO_PTR(r->s4));
+
+   printk("s5: %p, s6: %p, s7: %p, s8: %p\n",
+          TO_PTR(r->s5), TO_PTR(r->s6), TO_PTR(r->s7), TO_PTR(r->s8));
+
+   printk("s9: %p, s10: %p, s11: %p, t3: %p\n",
+          TO_PTR(r->s9), TO_PTR(r->s10), TO_PTR(r->s11), TO_PTR(r->t3));
+
+   printk("t4: %p, t5: %p, t6: %p, sepc: %p\n",
+          TO_PTR(r->t4), TO_PTR(r->t5), TO_PTR(r->t6), TO_PTR(r->sepc));
+
+   printk("sstatus: %p, sbadaddr: %p, scause: %p\n",
+          TO_PTR(r->sstatus), TO_PTR(r->sbadaddr), TO_PTR(r->scause));
+
+   printk("usersp: %p\n", TO_PTR(r->usersp));
 }
 
 int debug_qemu_turn_off_machine(void)
 {
-   NOT_IMPLEMENTED();
+   poweroff();
+   return 0;
 }
 
 void dump_raw_stack(ulong addr)
 {
-   NOT_IMPLEMENTED();
+   printk("Raw stack dump:\n");
+
+   for (int i = 0; i < 36; i += 4) {
+
+      printk("%p: ", TO_PTR(addr));
+
+      for (int j = 0; j < 4; j++) {
+         printk("%p ", *(void **)addr);
+         addr += sizeof(ulong);
+      }
+
+      printk("\n");
+   }
 }
+

--- a/kernel/arch/riscv/fault.c
+++ b/kernel/arch/riscv/fault.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
+
 #include <tilck/common/basic_defs.h>
 #include <tilck/common/printk.h>
-
 #include <tilck/kernel/hal.h>
 #include <tilck/kernel/interrupts.h>
 #include <tilck/kernel/fault_resumable.h>
@@ -34,33 +34,129 @@ const char *riscv_exception_names[32] =
    "Store(or AMO) page fault",
 };
 
+static void handle_generic_fault(regs_t *r)
+{
+   const int int_num = r->int_num;
+   handle_generic_fault_int(r, riscv_exception_names[int_num]);
+}
+
+static void handle_inst_illegal_fault(regs_t *r)
+{
+   const int int_num = r->int_num;
+   handle_inst_illegal_fault_int(r, riscv_exception_names[int_num]);
+}
+
+static void handle_bus_fault(regs_t *r)
+{
+   const int int_num = r->int_num;
+   handle_bus_fault_int(r, riscv_exception_names[int_num]);
+}
+
+static void handle_breakpoint(regs_t *r)
+{
+   /*
+    * Do nothing, literally. The purpose of this way of handling `int 3` is to
+    * allow during development to easily put a breakpoint in user-space code and
+    * from GDB (using remote debugging) to put a HW breakpoint here.
+    *
+    * On Linux, the behavior of `int 3` is quite different, but that's fine.
+    * This interrupt is anyway used only for debugging purposes. In the future,
+    * it is absolutely possible that Tilck will handle it in a different way.
+    * For the moment, the kernel offers no debugging features of userspace
+    * programs (= no such thing as ptrace).
+    */
+   asmVolatile("nop");
+}
+
 void set_fault_handler(int ex_num, void *ptr)
 {
-   NOT_IMPLEMENTED();
+   fault_handlers[ex_num] = (soft_int_handler_t) ptr;
 }
 
 void init_cpu_exception_handling(void)
 {
-   NOT_IMPLEMENTED();
+   csr_write(CSR_STVEC, &asm_trap_entry);
+
+   set_fault_handler(EXC_INST_MISALIGNED, handle_bus_fault);
+   set_fault_handler(EXC_INST_ACCESS, handle_generic_fault);
+   set_fault_handler(EXC_INST_ILLEGAL, handle_inst_illegal_fault);
+   set_fault_handler(EXC_BREAKPOINT, handle_breakpoint);
+   set_fault_handler(EXC_LOAD_MISALIGNED, handle_bus_fault);
+   set_fault_handler(EXC_LOAD_ACCESS, handle_generic_fault);
+   set_fault_handler(EXC_STORE_MISALIGNED, handle_bus_fault);
+   set_fault_handler(EXC_STORE_ACCESS, handle_generic_fault);
 }
 
 void handle_resumable_fault(regs_t *r)
 {
-   NOT_IMPLEMENTED();
+   struct task *curr = get_curr_task();
+
+   pop_nested_interrupt(); // the fault
+   disable_interrupts_forced();
+   set_return_register(curr->fault_resume_regs, 1u << regs_intnum(r));
+   context_switch(curr->fault_resume_regs);
 }
 
 static void fault_in_panic(regs_t *r)
 {
-   NOT_IMPLEMENTED();
+   const int int_num = r->int_num;
+
+   if (is_fault_resumable(int_num))
+      return handle_resumable_fault(r);
+
+   /*
+    * We might be so unlucky that printk() causes some fault(s) too: therefore,
+    * not even trying to print something on the screen is safe. In order to
+    * avoid generating an endless sequence of page faults in the worst case,
+    * just call printk() in SAFE way here.
+    */
+   fault_resumable_call(
+      ALL_FAULTS_MASK, printk, 5,
+      "FATAL: %s [%d] while in panic state [EIP: %p]\n",
+      riscv_exception_names[int_num], int_num, regs_get_ip(r));
+
+   /* Halt the CPU forever */
+   while (true) { halt(); }
 }
 
 void handle_fault(regs_t *r)
 {
-   NOT_IMPLEMENTED();
+   const int int_num = r->int_num;
+   bool cow = false;
+
+   ASSERT(is_fault(int_num));
+
+   if (UNLIKELY(in_panic()))
+      return fault_in_panic(r);
+
+   if (LIKELY((int_num == EXC_INST_PAGE_FAULT) ||
+              (int_num == EXC_LOAD_PAGE_FAULT) ||
+              (int_num == EXC_STORE_PAGE_FAULT))) {
+
+      cow = handle_potential_cow(r);
+   }
+
+   if (!cow) {
+
+      if (is_fault_resumable(int_num))
+         return handle_resumable_fault(r);
+
+      if (LIKELY(fault_handlers[int_num] != NULL)) {
+
+         fault_handlers[int_num](r);
+
+      } else {
+
+         panic("Unhandled fault #%i: %s EIP: %p",
+               int_num,
+               riscv_exception_names[int_num],
+               regs_get_ip(r));
+      }
+   }
 }
 
 void on_first_pdir_update(void)
 {
-   return;
+   /* do nothing */
 }
 

--- a/kernel/arch/riscv/fault_resumable.S
+++ b/kernel/arch/riscv/fault_resumable.S
@@ -11,6 +11,119 @@
 
 FUNC(fault_resumable_call):
 
+   save_fp_ra
+
+   addi sp, sp, -4 * RISCV_SZPTR
+
+   la t2, __disable_preempt           # push __disable_preempt
+   lw t1, (t2)
+   sw t1, 0 * RISCV_SZPTR(sp)
+
+   la t0, __current
+   REG_L t0, (t0)
+   REG_L t1, TI_F_RESUME_RS_OFF(t0)
+   REG_S t1, 2 * RISCV_SZPTR(sp)      # push current->fault_resume_regs
+
+   lw t1, TI_FAULTS_MASK_OFF(t0)
+   sw t1, 1 * RISCV_SZPTR(sp)         # push current->faults_resume_mask
+
+   save_callee_regs
+
+   la t2, .asm_fault_resumable_call_resume
+   REG_S t2, 37 * RISCV_SZPTR(sp)     # save kernel_resume_pc
+
+   la t0, __current
+   REG_L t0, (t0)
+   REG_S sp, TI_F_RESUME_RS_OFF(t0)   # save to current->fault_resume_regs
+
+   sw a0, TI_FAULTS_MASK_OFF(t0)      # arg1: faults_mask
+   mv s1, a1                          # arg2: func
+   mv s2, a2                          # arg3: nargs
+
+   // Place the first five parameters in A0 to A4
+
+   addi s2, s2, -5
+   mv a0, a3
+   mv a1, a4
+   mv a2, a5
+   mv a3, a6
+   mv a4, a7
+
+   // Take the next three parameters from the stack
+   // and place them in A5 to A7
+
+   mv s3, s0
+   mv s5, sp                         # backup sp
+
+   blez s2, 2f
+   addi s2, s2, -1
+   REG_L a5, (s3)
+
+   blez s2, 2f
+   addi s2, s2, -1
+   addi s3, s3, RISCV_SZPTR
+   REG_L a6, (s3)
+
+   blez s2, 2f
+   addi s2, s2, -1
+   addi s3, s3, RISCV_SZPTR
+   REG_L a7, (s3)
+
+   // Take the remaining parameters from the stack and
+   // put them on the stack
+
+   blez s2, 2f
+   slli s4, s2, RISCV_LOGSZPTR
+   mv s5, sp                         # backup sp
+   sub sp, sp, s4
+   andi sp, sp, ~(0xf)
+   mv s4, sp
+
+1:
+   addi s2, s2, -1
+   addi s3, s3, RISCV_SZPTR
+   REG_L t0, (s3)
+   REG_S t0, (s4)
+   addi s4, s4, RISCV_SZPTR
+   bgtz s2, 1b
+
+2:
+   jalr s1
+   mv a0, zero                       # return value: set to 0 (= no faults)
+   mv sp, s5
+
+   resume_callee_regs
+
+   la t0, __current
+   REG_L t0, (t0)
+   lw t1, 1 * RISCV_SZPTR(sp)
+   sw t1, TI_FAULTS_MASK_OFF(t0)     # pop current->faults_resume_mask
+
+   REG_L t1, 2 * RISCV_SZPTR(sp)
+   REG_S t1, TI_F_RESUME_RS_OFF(t0)  # pop current->fault_resume_regs
+   addi sp, sp, 4 * RISCV_SZPTR
+
+   restore_fp_ra
+   ret
+
+.asm_fault_resumable_call_resume:
+
+   resume_callee_regs
+
+   la t0, __current
+   REG_L t0, (t0)
+   lw t1, 1 * RISCV_SZPTR(sp)
+   sw t1, TI_FAULTS_MASK_OFF(t0)
+
+   REG_L t1, 2 * RISCV_SZPTR(sp)
+   REG_S t1, TI_F_RESUME_RS_OFF(t0)
+
+   la t0, __disable_preempt          # pop __disable_preempt
+   lw t1, 0 * RISCV_SZPTR(sp)
+   sw t1, (t0)
+   addi sp, sp, 4 * RISCV_SZPTR
+
+   restore_fp_ra
    ret
 
 END_FUNC(fault_resumable_call)

--- a/kernel/arch/riscv/panic.c
+++ b/kernel/arch/riscv/panic.c
@@ -31,11 +31,186 @@ regs_t panic_state_regs;
 /* Called by the assembly function panic_save_current_state() */
 void panic_save_current_task_state(regs_t *r)
 {
-   NOT_IMPLEMENTED();
+   /*
+    * Since in panic we need just to save the state without doing a context
+    * switch, just saving the ESP in state_regs won't work, because
+    * we'll going to continue using the same stack. In this particular corner
+    * case, just store the regs in a static regs_t instance.
+    */
+   memcpy(&panic_state_regs, r, sizeof(regs_t));
+   struct task *curr = get_curr_task();
+
+   if (curr)
+      curr->state_regs = &panic_state_regs;
+}
+
+static void disable_fpu_features(void)
+{
+   riscv_cpu_features.isa_exts.f = false;
+   riscv_cpu_features.isa_exts.d = false;
+   riscv_cpu_features.isa_exts.q = false;
+}
+
+static void panic_print_task_info(struct task *curr)
+{
+   const char *str;
+
+   if (curr && curr != kernel_process && curr->tid != -1) {
+
+      if (!is_kernel_thread(curr)) {
+
+         printk("Current task [USER]: tid: %i, pid: %i\n",
+                curr->tid, curr->pi->pid);
+
+      } else {
+
+         str = curr->kthread_name;
+         printk("Current task [KERNEL]: tid: %i [%s]\n",
+                curr->tid, str ? str : "???");
+      }
+   } else {
+      printk("Current task: NONE\n");
+   }
+}
+
+static int
+stop_all_other_tasks(void *task, void *unused)
+{
+   struct task *ti = task;
+
+   if (ti != get_curr_task()) {
+      ti->stopped = true;
+   }
+
+   return 0;
 }
 
 NORETURN void panic(const char *fmt, ...)
 {
-   NOT_IMPLEMENTED();
+   static bool first_printk_ok;
+   static const char *saved_fmt;
+   static va_list saved_args;
+
+   ulong rc;
+   va_list args;
+   struct task *curr;
+
+   if (!kopt_panic_kb) {
+
+      /* No interrupts: we're in a panic state */
+      disable_interrupts_forced();
+
+   } else {
+
+      /*
+       * While it's a good idea to disable ALL the interrupts during panic(),
+       * sometimes the panic code path does not affect screen scrolling nor
+       * the console, nor the PS/2 driver. Therefore, in those cases, it's
+       * great to reproduce the bug and being able to scroll.
+       *
+       * Therefore, let's mask all the IRQs except the IRQ for the PS/2
+       * keyboard.
+       */
+      disable_interrupts_forced();
+
+      for (int irq = 16; irq < MAX_IRQ_NUM; irq++) {
+
+         extern int console_irq;
+         extern int plic_irq;
+
+         if (irq != console_irq && irq != plic_irq)
+            irq_set_mask(irq);
+      }
+
+      disable_preemption();
+      iterate_over_tasks(&stop_all_other_tasks, NULL);
+      enable_interrupts_forced();
+   }
+
+   force_enable_preemption();   /* Set a predefined and sane state */
+
+   if (__in_panic) {
+
+      /* Ouch, nested panic! */
+      if (first_printk_ok)
+         printk("[panic] Got panic while in panic state. Halt.\n");
+
+      goto end;
+   }
+
+   __in_panic = true;
+   va_start(args, fmt);
+
+   if (!saved_fmt) {
+
+      saved_fmt = fmt;
+      va_copy(saved_args, args);
+   }
+
+   disable_fpu_features();
+   panic_save_current_state();
+   curr = get_curr_task();
+
+   if (term_is_initialized()) {
+
+      if (get_curr_tty() != NULL)
+         tty_setup_for_panic(get_curr_tty());
+
+      /* In case the video output has been paused, we MUST restart it */
+      term_restart_output();
+
+   } else {
+
+      init_console();
+   }
+
+   /* Hopefully, we can show something on the screen */
+   printk("\n********************** KERNEL PANIC **********************\n");
+
+   /*
+    * Register the fact that the first printk() succeeded: in case of panic
+    * in panic, at least we know that we can show something on the screen.
+    */
+   first_printk_ok = true;
+
+   /* print the arguments in a fault-safe way */
+   rc = fault_resumable_call(ALL_FAULTS_MASK, vprintk, 2, fmt, args);
+
+   if (rc != 0) {
+      printk("[panic] Got fault %d while trying to print "
+             "the panic message.", get_fault_num(rc));
+   }
+
+   va_end(args);
+   printk("\n");
+
+   panic_print_task_info(curr);
+   panic_dump_nested_interrupts();
+
+   if (kopt_panic_regs)
+      dump_regs(&panic_state_regs);
+
+   if (!kopt_panic_nobt) {
+      dump_stacktrace(
+         regs_get_frame_ptr(&panic_state_regs),
+         curr ? curr->pi->pdir : NULL
+      );
+   }
+
+   if (kopt_panic_mmap)
+      dump_memory_map();
+
+   if (DEBUG_QEMU_EXIT_ON_PANIC)
+      debug_qemu_turn_off_machine();
+
+   if (kopt_panic_kb) {
+      __in_panic_debugger = true;
+      sys_tilck_cmd(TILCK_CMD_DEBUGGER_TOOL, 0, 0, 0, 0);
+   }
+
+end:
+   /* Halt the CPU forever */
+   disable_interrupts_forced();
+   while (true) { halt(); }
 }
 

--- a/kernel/arch/riscv/trap_entry.S
+++ b/kernel/arch/riscv/trap_entry.S
@@ -12,14 +12,79 @@
 .align 3
 FUNC(asm_trap_entry):
 
+   # load kernel sp from sscratch, if is zero
+   # then it indicates trap is from kernel
+   csrrw sp, sscratch, sp
+   bnez sp, .from_user
+
+.from_kernel:
+   csrrw sp, sscratch, sp
+
+.from_user:
+   save_all_regs
+
+   la ra, asm_trap_entry_resume
+   REG_S ra, 37 * RISCV_SZPTR(sp)   # save kernel_resume_pc
+
+   csrw sscratch, zero              # sscratch always equal zero in kernel
+
+   # Disable the FPU in kernel space
+   li t0, SR_FS
+   csrc sstatus, t0
+
+   # save framepointer, then we can trace back
+   # to the function before the interrupt
+   addi s0, sp, (10 * RISCV_SZPTR)
+   mv a0, sp
+
+   csrr t0, scause
+   blt t0, zero, .handle_irq
+
+   REG_S t0, 36 * RISCV_SZPTR(sp)   # save int_num
+
+   li t1, EXC_SYSCALL
+   beq t1, t0, .handle_syscall
+
+   tail fault_entry
+
+.handle_syscall:
+   tail syscall_entry
+
+.handle_irq:
+   li t1, 1 << (__riscv_xlen - 1)
+   not t1, t1
+   and t0, t0, t1
+   addi t0, t0, 32
+   REG_S t0, 36 * RISCV_SZPTR(sp)   # save int_num
+
+   tail irq_entry
+
+asm_trap_entry_resume:
+   csrci sstatus, SR_SIE
+   REG_L t0, 33 * RISCV_SZPTR(sp)   # load sstatus
+   andi t0, t0, SR_SPP
+   bnez t0, .resume_kernel
+
+.resume_user:
+   REG_L t1, 38 * RISCV_SZPTR(sp)
+   REG_S t1,  2 * RISCV_SZPTR(sp)   # restore usersp
+
+   addi t0, sp, SIZEOF_REGS
+   csrw sscratch, t0                # save kernel sp in sscratch
+
+.resume_kernel:
+   resume_all_regs
    sret
 
 END_FUNC(asm_trap_entry)
 
-
 FUNC(context_switch):
 
-   ret
+   mv sp, a0  # Make SP = function's 1st (and only) argument: regs *contex.
+   REG_L ra, 37 * RISCV_SZPTR(sp)
+   ret        # Now ra's value is `kernel_resume_pc`.
+              # By default, that value is `asm_trap_entry_resume` or
+              # 'kernel_yield_resume'
 
 END_FUNC(context_switch)
 

--- a/modules/irqchip/riscv/riscv-plic.c
+++ b/modules/irqchip/riscv/riscv-plic.c
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#include <tilck_gen_headers/config_debug.h>
+
+#include <tilck/common/basic_defs.h>
+#include <tilck/common/utils.h>
+#include <tilck/common/printk.h>
+#include <tilck/kernel/errno.h>
+#include <tilck/kernel/hal.h>
+#include <tilck/kernel/irq.h>
+#include <tilck/kernel/sched.h>
+#include <tilck/kernel/kmalloc.h>
+#include <3rd_party/fdt_helper.h>
+#include <libfdt.h>
+
+int plic_irq;
+

--- a/modules/serial/riscv/fdt_serial.c
+++ b/modules/serial/riscv/fdt_serial.c
@@ -20,10 +20,13 @@
 #define X86_PC_COM2_COM4_IRQ       3
 #define X86_PC_COM1_COM3_IRQ       4
 
+int console_irq;
 
 void init_serial_port(u16 port)
 {
-   /* do nothing */
+   /* TODO: just for debug now, this code will be removed soon */
+   extern bool kopt_sercon;
+   kopt_sercon = true;
 }
 
 bool serial_read_ready(u16 port)
@@ -54,5 +57,6 @@ char serial_read(u16 port)
 
 void serial_write(u16 port, char c)
 {
-   NOT_IMPLEMENTED();
+   /* TODO: just for debug now, this code will be removed soon */
+   sbi_console_putchar(c);
 }


### PR DESCRIPTION
Hi @vvaltchev 

In `fdt_serial.c`, I added some temporary code, mainly to enable early serial output. When the serial driver is updated in the future, these temporary code will be overwritten.