### PR TITLE
[riscv64] Introduce a simple irqchip framework

### DIFF
--- a/include/tilck/mods/irqchip.h
+++ b/include/tilck/mods/irqchip.h
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#pragma once
+
+#include <tilck/common/basic_defs.h>
+#include <tilck/kernel/list.h>
+
+#define FDT_MAX_INTERRUPTS_PARAMS 16
+
+enum irq_type {
+   IRQ_TYPE_NONE           = 0x00000000,
+   IRQ_TYPE_EDGE_RISING    = 0x00000001,
+   IRQ_TYPE_EDGE_FALLING   = 0x00000002,
+   IRQ_TYPE_EDGE_BOTH      = (IRQ_TYPE_EDGE_FALLING | IRQ_TYPE_EDGE_RISING),
+   IRQ_TYPE_LEVEL_HIGH     = 0x00000004,
+   IRQ_TYPE_LEVEL_LOW      = 0x00000008,
+};
+
+struct fdt_irq_param {
+   int intc_node;
+   int param_nums;
+   u32 params[FDT_MAX_INTERRUPTS_PARAMS];
+};
+
+struct fdt_irqchip {
+   struct list_node node;
+   const struct fdt_match *id_table;
+   int (*init)(void *fdt, int node, const struct fdt_match *match);
+};
+
+struct fdt_irqchip_ops {
+   void (*hwirq_set_mask)(int hwirq, void *priv);
+   void (*hwirq_clear_mask)(int hwirq, void *priv);
+   bool (*hwirq_is_masked)(int hwirq, void *priv);
+   void (*hwirq_set_type)(int hwirq, int type, void *priv);
+   int (*xlate_irq_param)(struct fdt_irq_param *param,
+                          int *hwirq, int *type, void *priv);
+};
+
+struct irq_domain {
+   void *priv;
+   struct list_node node;
+   int fdt_node;
+   struct fdt_irqchip_ops *ops;
+   size_t irq_map_size;
+   int irq_map[];
+};
+
+struct irq_data {
+   bool present;
+   u32 hwirq;
+   enum irq_type type;
+   u32 unhandled_count;
+   struct irq_domain *domain;
+};
+
+#define REGISTER_FDT_IRQCHIP(__name, __id_table, __init)  \
+                                                          \
+   static struct fdt_irqchip fdt_irqchip_##__name = {     \
+      .id_table = __id_table,                             \
+      .init = __init                                      \
+   };                                                     \
+                                                          \
+   __attribute__((constructor))                           \
+   static void __register_fdt_irqchip_##__name(void) {    \
+      irqchip_drv_register(&fdt_irqchip_##__name);        \
+   }
+
+int fdt_parse_one_hwirq(void *fdt,
+                        int node,
+                        int index,
+                        struct fdt_irq_param *irq_param);
+
+int default_xlate_irq_param(struct fdt_irq_param *param,
+                            int *hwirq,
+                            int *type,
+                            void *priv);
+
+struct irq_domain *
+irqchip_register_irq_domain(void *priv,
+                            int fdt_node,
+                            int int_nums,
+                            struct fdt_irqchip_ops *ops);
+
+void irqchip_drv_register(struct fdt_irqchip *drv);
+int irqchip_get_irq_count(void *fdt, int node);
+int irqchip_alloc_irq(void *fdt, int node, int hwirq_index);
+void irqchip_free_irq(int irq);
+int irqchip_get_free_irq(struct irq_domain *domain, int hwirq);
+void irqchip_put_irq(int irq);
+enum irq_action generic_irq_handler(u8 irq);
+void init_fdt_irqchip(void);
+

--- a/kernel/arch/riscv/cpu.c
+++ b/kernel/arch/riscv/cpu.c
@@ -17,7 +17,8 @@ void asm_restore_fpu(void *buf);
 
 void enable_cpu_features(void)
 {
-   NOT_IMPLEMENTED();
+   /* TODO: will be completed soon in later commit */
+   get_cpu_features();
 }
 
 void save_current_fpu_regs(bool in_kernel)

--- a/kernel/arch/riscv/irq.c
+++ b/kernel/arch/riscv/irq.c
@@ -12,48 +12,124 @@
 #include <tilck/kernel/worker_thread.h>
 #include <tilck/kernel/timer.h>
 
+#include <tilck/mods/irqchip.h>
+
+extern struct irq_data irq_datas[MAX_IRQ_NUM];
+extern ulong irq_bitmap[MAX_IRQ_NUM / (sizeof(ulong) * 8)];
 
 struct list irq_handlers_lists[MAX_IRQ_NUM];
 
 void irq_set_mask(int irq)
 {
-   NOT_IMPLEMENTED();
+   ulong var;
+   u32 hwirq;
+   struct irq_domain *domain;
+   ASSERT(IN_RANGE_INC(irq, 0, MAX_IRQ_NUM - 1));
+
+   disable_interrupts(&var);
+   if (irq_datas[irq].present) {
+      domain = irq_datas[irq].domain;
+      hwirq = irq_datas[irq].hwirq;
+      domain->ops->hwirq_set_mask(hwirq, domain->priv);
+   }
+   enable_interrupts(&var);
 }
 
 void irq_clear_mask(int irq)
 {
-   NOT_IMPLEMENTED();
+   ulong var;
+   u32 hwirq;
+   struct irq_domain *domain;
+   ASSERT(IN_RANGE_INC(irq, 0, MAX_IRQ_NUM - 1));
+
+   disable_interrupts(&var);
+   if (irq_datas[irq].present) {
+      domain = irq_datas[irq].domain;
+      hwirq = irq_datas[irq].hwirq;
+      domain->ops->hwirq_clear_mask(hwirq, domain->priv);
+   }
+   enable_interrupts(&var);
 }
 
 bool irq_is_masked(int irq)
 {
-   NOT_IMPLEMENTED();
+   ulong var;
+   u32 hwirq;
+   struct irq_domain *domain;
+   bool ret;
+
+   ASSERT(IN_RANGE_INC(irq, 0, MAX_IRQ_NUM - 1));
+
+   disable_interrupts(&var);
+   if (irq_datas[irq].present) {
+      domain = irq_datas[irq].domain;
+      hwirq = irq_datas[irq].hwirq;
+      ret = domain->ops->hwirq_is_masked(hwirq, domain->priv);
+   }
+   enable_interrupts(&var);
+   return ret;
 }
 
 /* This installs a custom IRQ handler for the given IRQ */
 void irq_install_handler(u8 irq, struct irq_handler_node *n)
 {
-   NOT_IMPLEMENTED();
+   ulong var;
+   disable_interrupts(&var);
+   {
+      list_add_tail(&irq_handlers_lists[irq], &n->node);
+   }
+   enable_interrupts(&var);
+   irq_clear_mask(irq);
 }
 
 /* This clears the handler for a given IRQ */
 void irq_uninstall_handler(u8 irq, struct irq_handler_node *n)
 {
-   NOT_IMPLEMENTED();
+   ulong var;
+   disable_interrupts(&var);
+   {
+      list_remove(&n->node);
+
+      if (list_is_empty(&irq_handlers_lists[irq]))
+         irq_set_mask(irq);
+   }
+   enable_interrupts(&var);
 }
 
 int get_irq_num(regs_t *context)
 {
-   NOT_IMPLEMENTED();
+   return int_to_irq(context->int_num);
 }
 
 int get_int_num(regs_t *context)
 {
-   NOT_IMPLEMENTED();
+   return context->int_num;
 }
 
 void init_irq_handling(void)
 {
-   NOT_IMPLEMENTED();
+   ASSERT(!are_interrupts_enabled());
+
+   /* Make all irq numbers available */
+   for (ulong i = 0; i < MAX_IRQ_NUM / sizeof(ulong); i++) {
+      irq_bitmap[i] = 0;
+   }
+
+   /*
+    * The serial port and timer interrupt numbers in tilck are fixed numbers,
+    * we reserve 0 ~ 15 IRQ numbers.
+    */
+   irq_bitmap[0] |= 0xffffUL;
+
+   for (int i = 0; i < MAX_IRQ_NUM; i++) {
+
+      list_init(&irq_handlers_lists[i]);
+      irq_datas[i].hwirq = 0;
+      irq_datas[i].unhandled_count = 0;
+      irq_datas[i].domain = 0;
+      irq_datas[i].present = false;
+   }
+
+   init_fdt_irqchip();
 }
 

--- a/kernel/arch/riscv/mmap.c
+++ b/kernel/arch/riscv/mmap.c
@@ -5,18 +5,23 @@
 
 #include "paging_int.h"
 
-#define MAX_DMA                                (256 * KB)
-
-STATIC_ASSERT(MAX_DMA <= 16 * MB);
-STATIC_ASSERT((MAX_DMA & (64 * KB - 1)) == 0);
-
 void arch_add_initial_mem_regions()
 {
-   NOT_IMPLEMENTED();
+   /*
+    * Reserve 1MB below kernel's head, where
+    * the flattened device tree is located.
+    */
+   append_mem_region((struct mem_region) {
+      .addr = KERNEL_VA_TO_PA(KERNEL_VADDR) - (1 * MB),
+      .len = 1 * MB,
+      .type = MULTIBOOT_MEMORY_RESERVED,
+      .extra = MEM_REG_EXTRA_LOWMEM,
+   });
 }
 
 bool arch_add_final_mem_regions()
 {
-   NOT_IMPLEMENTED();
+   /* do nothing */
+   return false;
 }
 

--- a/kernel/arch/riscv64/linker_script.ld
+++ b/kernel/arch/riscv64/linker_script.ld
@@ -48,20 +48,6 @@ SECTIONS
       *(.init_array)
    } : ro_segment
 
-   . = ALIGN(4);
-   .modules : AT(kernel_text_paddr + (modules - text))
-   {
-      modules = .;
-      KEEP(*(SORT(.modules.*)));
-   } : ro_segment
-
-   .simplebus_driver : AT(kernel_text_paddr + (_simplebus_start - text))
-   {
-      _simplebus_start = .;
-      *(.simplebus_driver)
-      _simplebus_end = .;
-   } : ro_segment
-
    .tilck_info : AT(kernel_text_paddr + (tilck_info - text))
    {
       tilck_info = .;
@@ -85,12 +71,6 @@ SECTIONS
    {
       bss = .;
       *(.bss .bss.* .gnu.linkonce.b.*)
-   } : rw_segment
-
-   .sbss : AT(kernel_text_paddr + (sbss - text))
-   {
-      sbss = .;
-      *(.sbss .sbss.*)
    } : rw_segment
    __bss_stop = .;
 

--- a/modules/irqchip/riscv/fdt_irqchip.c
+++ b/modules/irqchip/riscv/fdt_irqchip.c
@@ -11,6 +11,362 @@
 #include <tilck/kernel/errno.h>
 #include <tilck/kernel/kmalloc.h>
 #include <tilck/kernel/sched.h>
+#include <tilck/mods/irqchip.h>
+#include <3rd_party/fdt_helper.h>
+#include <libfdt.h>
+
+#define MAX_IRQCHIP_NUM 16
+
+struct intc_dev {
+   int intc;
+   int parent_intc;
+   struct fdt_irqchip *drv;
+   const struct fdt_match *match;
+};
+
+struct irq_data irq_datas[MAX_IRQ_NUM];
+ulong irq_bitmap[MAX_IRQ_NUM / (sizeof(ulong) * 8)];
 
 u32 spur_irq_count = 0;
 u32 unhandled_irq_count[MAX_IRQ_NUM];
+
+static struct list drv_list = STATIC_LIST_INIT(drv_list);
+static struct list irq_domains = STATIC_LIST_INIT(irq_domains);
+
+int irqchip_get_free_irq(struct irq_domain *domain, int hwirq)
+{
+   for (int i = 0; i < ARRAY_SIZE(irq_bitmap); i++) {
+
+      if (~irq_bitmap[i]) {
+         ulong idx = get_first_zero_bit_index_l(irq_bitmap[i]);
+         int irq = (int)(i * NBITS + idx);
+
+         irq_bitmap[i] |= 1 << idx;
+         irq_datas[irq].hwirq = hwirq;
+         irq_datas[irq].domain = domain;
+         irq_datas[irq].present = true;
+         return irq;
+      }
+   }
+
+   return -EINVAL;
+}
+
+void irqchip_put_irq(int irq)
+{
+   ASSERT(irq > 0 && irq < MAX_IRQ_NUM);
+   ulong slot = irq / NBITS;
+   ulong index = irq % NBITS;
+
+   irq_bitmap[slot] &= ~(1 << index);
+   irq_datas[irq].present = false;
+}
+
+enum irq_action generic_irq_handler(u8 irq)
+{
+   enum irq_action hret = IRQ_NOT_HANDLED;
+   struct irq_handler_node *pos;
+
+   list_for_each_ro(pos, &irq_handlers_lists[irq], node) {
+
+      hret = pos->handler(pos->context);
+      if (hret != IRQ_NOT_HANDLED)
+         break;
+   }
+
+   if (hret == IRQ_NOT_HANDLED) {
+      irq_datas[irq].unhandled_count++;
+      unhandled_irq_count[irq]++;
+   }
+
+   return hret;
+}
+
+int default_xlate_irq_param(struct fdt_irq_param *param,
+                            int *hwirq,
+                            int *type,
+                            void *priv)
+{
+   if (param->param_nums == 1) {
+
+      *hwirq = param->params[0];
+      *type = IRQ_TYPE_NONE;
+
+   } else if (param->param_nums == 2) {
+
+      *hwirq = param->params[0];
+      *type = param->params[1];
+
+   } else {
+
+      printk("irqchip: ERROR: wrong irq parammetet numbers\n");
+      return -EINVAL;
+   }
+
+   return 0;
+}
+
+/*
+ * Only "interrupts-extended" and "interrupts" formats have been parsed here,
+ * and the "interrupt-map" format has not been processed.
+ */
+int fdt_parse_one_hwirq(void *fdt, int node, int index,
+                        struct fdt_irq_param *irq_param)
+{
+   int len, rc;
+   int intc_node, parent_node;
+   const fdt32_t *val;
+   u32 ints_cells, intc_phandle;
+   struct fdt_phandle_args pargs;
+
+   /* 1. Try parse "interrupts-extended" fdt format */
+
+   rc = fdt_parse_phandle_with_args(fdt, node, "interrupts-extended",
+                                    "#interrupt-cells", index, &pargs);
+
+   if (!rc) {
+      irq_param->intc_node = pargs.node_offset;
+      irq_param->param_nums = pargs.args_count;
+
+      for (int i = 0; i < pargs.args_count; i++) {
+         irq_param->params[i] = pargs.args[i];
+      }
+      return 0;
+   }
+
+   /* 2. Try parse "interrupts" fdt format */
+
+   for (parent_node = node;
+        fdt_node_depth(fdt, parent_node) > 0;
+        parent_node = fdt_parent_offset(fdt, parent_node))
+   {
+      val = fdt_getprop(fdt, parent_node, "interrupt-parent", &len);
+      if (val) {
+         intc_phandle = fdt32_to_cpu(*val);
+         break;
+      }
+   }
+
+   intc_node = fdt_node_offset_by_phandle(fdt, intc_phandle);
+   if (intc_node < 0 || fdt_node_depth(fdt, parent_node) <= 0)
+      return -ENODEV;
+
+   val = fdt_getprop(fdt, intc_node, "#interrupt-cells", &len);
+   if (!val)
+      return -ENODEV;
+
+   ints_cells = fdt32_to_cpu(*val);
+   if (ints_cells > FDT_MAX_INTERRUPTS_PARAMS)
+      return -EINVAL;
+
+   val = fdt_getprop(fdt, node, "interrupts", &len);
+   if (!val)
+      return -ENODEV;
+
+   // Check if the index is within the parameter range
+   if (index * ints_cells >= len / sizeof(*val))
+      return -EINVAL;
+
+   for (u32 i = 0; i < ints_cells; i++)
+      irq_param->params[i] = fdt32_to_cpu(val[index * ints_cells + i]);
+
+   irq_param->intc_node = intc_node;
+   irq_param->param_nums = ints_cells;
+   return 0;
+}
+
+int irqchip_get_irq_count(void *fdt, int node)
+{
+   struct fdt_irq_param irq_param;
+   int index = 0;
+   int rc = 0;
+
+   while (rc == 0) {
+      rc = fdt_parse_one_hwirq(fdt, node, index, &irq_param);
+      index++;
+   }
+
+   return index;
+}
+
+int irqchip_alloc_irq(void *fdt, int node, int hwirq_index)
+{
+   struct irq_domain *domain, *tmp;
+   struct fdt_irq_param irq_param;
+   int irq = 0, rc;
+   int hwirq, type;
+
+   rc = fdt_parse_one_hwirq(fdt, node, hwirq_index, &irq_param);
+   if (rc)
+      return 0;
+
+   disable_preemption();
+
+   /* Find the corresponding irq domain */
+   list_for_each(domain, tmp, &irq_domains, node) {
+
+      if (domain->fdt_node != irq_param.intc_node)
+         continue;
+
+      if (domain->ops->xlate_irq_param) {
+         rc = domain->ops->xlate_irq_param(&irq_param, &hwirq,
+                                           &type, domain->priv);
+      } else {
+         rc = default_xlate_irq_param(&irq_param, &hwirq,
+                                      &type, NULL);
+      }
+
+      if (rc) {
+         enable_preemption();
+         return 0;
+      }
+
+      irq = irqchip_get_free_irq(domain, hwirq);
+      if (irq < 0) {
+         enable_preemption();
+         return -EINVAL;
+      }
+
+      if (domain->ops->hwirq_set_type)
+         domain->ops->hwirq_set_type(hwirq, type, domain->priv);
+
+      domain->irq_map[hwirq] = irq;
+      break;
+   }
+
+   enable_preemption();
+   return irq;
+}
+
+void irqchip_free_irq(int irq)
+{
+   struct irq_domain *domain, *tmp;
+
+   disable_preemption();
+
+   list_for_each(domain, tmp, &irq_domains, node) {
+
+      for (u32 i = 0; i < domain->irq_map_size; i++) {
+
+         if (domain->irq_map[i] == irq) {
+
+            domain->irq_map[i] = 0;
+            irqchip_put_irq(irq);
+            enable_preemption();
+            return;
+         }
+      }
+   }
+
+   enable_preemption();
+}
+
+struct irq_domain *
+irqchip_register_irq_domain(void *priv,
+                            int fdt_node,
+                            int int_nums,
+                            struct fdt_irqchip_ops *ops)
+{
+   struct irq_domain *domain;
+
+   domain = kzmalloc(sizeof(*domain) + int_nums * sizeof(int));
+   if (!domain)
+      return NULL;
+
+   domain->fdt_node = fdt_node;
+   domain->irq_map_size = int_nums;
+   domain->ops = ops;
+   domain->priv = priv;
+
+   disable_preemption();
+   list_add_tail(&irq_domains, &domain->node);
+   enable_preemption();
+   return domain;
+}
+
+void irqchip_drv_register(struct fdt_irqchip *drv)
+{
+   list_add_tail(&drv_list, &drv->node);
+}
+
+void init_fdt_irqchip(void)
+{
+   const struct fdt_match *matched;
+   struct fdt_irqchip *drv;
+   struct fdt_irq_param irq_param;
+   const fdt32_t *val;
+   struct intc_dev *intc_nodes, *intc_done;
+   int node, parent_intc, len;
+   bool enabled;
+   int intc_cnt = 0;
+   int intc_done_index = 0;
+   int intc_done_cnt = 0;
+
+   void *fdt = fdt_get_address();
+
+   intc_nodes = kzmalloc(MAX_IRQCHIP_NUM * sizeof(*intc_nodes));
+   if (!intc_nodes) {
+      printk("irqchip: ERROR: failed to alloc intc_nodes!\n");
+      return;
+   }
+
+   intc_done = kzmalloc(MAX_IRQCHIP_NUM * sizeof(*intc_done));
+   if (!intc_done) {
+      printk("irqchip: ERROR: failed to alloc intc_done!\n");
+      return;
+   }
+
+   for (node = fdt_next_node(fdt, -1, NULL);
+        node >= 0;
+        node = fdt_next_node(fdt, node, NULL))
+   {
+      list_for_each_ro(drv, &drv_list, node) {
+
+         enabled = fdt_node_is_enabled(fdt, node);
+         matched = fdt_match_node(fdt, node, drv->id_table);
+         val = fdt_getprop(fdt, node, "interrupt-controller", &len);
+
+         if (enabled && matched && val) {
+            if (fdt_parse_one_hwirq(fdt, node, 0, &irq_param) == 0) {
+               intc_nodes[intc_cnt].parent_intc = irq_param.intc_node;
+            } else {
+               //root interrupt controller
+               intc_nodes[intc_cnt].parent_intc = -1;
+            }
+
+            intc_nodes[intc_cnt].intc = node;
+            intc_nodes[intc_cnt].drv = drv;
+            intc_nodes[intc_cnt].match = matched;
+            intc_cnt++;
+            break;
+         }
+      }
+   }
+
+   intc_done[0].intc = -1;
+
+   /*
+    * Initialization is performed sequentially from the root node
+    * according to the dependencies of the interrupt controller.
+    */
+   while (intc_done_cnt < intc_cnt) {
+
+      parent_intc = intc_done[intc_done_index].intc;
+      ASSERT(intc_done_index <= intc_done_cnt);
+      intc_done_index++;
+
+      for (int i = 0; i < intc_cnt; i++) {
+         if (intc_nodes[i].parent_intc == parent_intc) {
+
+            intc_done[intc_done_cnt + 1] = intc_nodes[i];
+            intc_done_cnt++;
+            intc_nodes[i].drv->init(fdt, intc_nodes[i].intc,
+                                    intc_nodes[intc_cnt].match);
+         }
+      }
+   }
+
+   kfree(intc_nodes);
+   kfree(intc_done);
+}
+

--- a/modules/irqchip/riscv/riscv-intc.c
+++ b/modules/irqchip/riscv/riscv-intc.c
@@ -4,13 +4,108 @@
 
 #include <tilck/common/basic_defs.h>
 #include <tilck/common/utils.h>
+#include <tilck/common/printk.h>
 #include <tilck/kernel/errno.h>
 #include <tilck/kernel/hal.h>
 #include <tilck/kernel/irq.h>
 #include <tilck/kernel/sched.h>
 #include <tilck/kernel/kmalloc.h>
+#include <3rd_party/fdt_helper.h>
+#include <libfdt.h>
+
+#include <tilck/mods/irqchip.h>
+
+#define INTERRUPT_CAUSE_FLAG	(1UL << (__riscv_xlen - 1))
+
+struct irq_domain *root_domain;
+
+static void hart_set_mask(int hwirq, void *priv)
+{
+   csr_clear(CSR_SIE, 1 << hwirq);
+}
+
+static void hart_clear_mask(int hwirq, void *priv)
+{
+   csr_set(CSR_SIE, 1 << hwirq);
+}
+
+static bool hart_is_masked(int hwirq, void *priv)
+{
+   return !(csr_read(CSR_SIE) & (1 << hwirq));
+}
 
 void arch_irq_handling(regs_t *r)
 {
-   NOT_IMPLEMENTED();
+   int hwirq, irq;
+
+   ASSERT(!are_interrupts_enabled());
+   ASSERT(!is_preemption_enabled());
+
+   hwirq = r->scause & ~INTERRUPT_CAUSE_FLAG;
+   irq = root_domain->irq_map[hwirq];
+   ASSERT(irq);
+
+   push_nested_interrupt(regs_intnum(r));
+   {
+      generic_irq_handler(irq);
+   }
+   pop_nested_interrupt();
 }
+
+struct fdt_irqchip_ops riscv_intc_ops = {
+   .hwirq_set_mask = hart_set_mask,
+   .hwirq_clear_mask = hart_clear_mask,
+   .hwirq_is_masked = hart_is_masked,
+};
+
+int riscv_intc_init(void *fdt, int node, const struct fdt_match *match)
+{
+   int len, rc, cpu_node;
+   const fdt32_t *val;
+   u64 cpuid;
+
+   /* Find which hart is doing initialize */
+
+   cpu_node = fdt_parent_offset(fdt, node);
+   if (cpu_node < 0)
+      return -EINVAL;
+
+   val = fdt_getprop(fdt, cpu_node, "device_type", &len);
+   if (!val)
+      return -EINVAL;
+
+   if (strncmp ((char *)val, "cpu", strlen ("cpu")))
+      return -EINVAL;
+
+   rc = fdt_get_node_addr_size(fdt, cpu_node, 0, &cpuid, NULL);
+   if (rc)
+      return -EINVAL;
+
+   /* We only initialize riscv intc on the boot HART */
+   if (cpuid != (u64)get_boothartid())
+      return 0;
+
+   root_domain = irqchip_register_irq_domain(NULL,
+                                             node,
+                                             16,
+                                             &riscv_intc_ops);
+   if (!root_domain) {
+      printk("riscv-intc: ERROR: unable to register IRQ domain\n");
+      return -EINVAL;
+   }
+
+   /* Mask all interrupts */
+   for (int i = 0; i < 16; i++) {
+      hart_set_mask(i, NULL);
+   }
+
+   return 0;
+}
+
+static const struct fdt_match riscv_intc_ids[] = {
+   {.compatible = "riscv,cpu-intc"},
+   { }
+};
+
+REGISTER_FDT_IRQCHIP(riscv_intc, riscv_intc_ids, riscv_intc_init)
+

--- a/modules/irqchip/riscv/riscv-plic.c
+++ b/modules/irqchip/riscv/riscv-plic.c
@@ -10,8 +10,272 @@
 #include <tilck/kernel/irq.h>
 #include <tilck/kernel/sched.h>
 #include <tilck/kernel/kmalloc.h>
+#include <tilck/mods/irqchip.h>
 #include <3rd_party/fdt_helper.h>
 #include <libfdt.h>
 
+#define SPRIORITY_BASE      0
+#define SPRIORITY_PER_ID    4
+
+#define SENABLE_BASE        0x2080
+#define SENABLE_PER_HART    0x80
+
+#define SCONTEXT_BASE       0x201000
+#define SCONTEXT_PER_HART   0x1000
+#define SCONTEXT_THRESHOLD  0x00
+#define SCONTEXT_CLAIM      0x04
+
+/* Only used to record the boot hart */
+struct plic_per_hart {
+   int hart_id;
+   int irq_index;
+   void *priority_base;
+   void *context_base;
+   void *enable_base;
+};
+
+struct plic_base {
+   void *base;
+   ulong paddr;
+   ulong size;
+   ulong int_nums;
+   struct plic_per_hart plic_hart;
+   struct irq_domain *domain;
+};
+
 int plic_irq;
+
+static int
+fdt_parse_plic(void *fdt, int node, struct plic_base *plic)
+{
+   int len, rc;
+   const fdt32_t *val;
+   u64 addr, size;
+
+   if (node < 0 || !plic || !fdt)
+      return -ENODEV;
+
+   rc = fdt_get_node_addr_size(fdt, node, 0, &addr, &size);
+   if (rc < 0 || !addr || !size)
+      return -ENODEV;
+
+   plic->paddr = addr;
+   plic->size = size;
+
+   val = fdt_getprop(fdt, node, "riscv,ndev", &len);
+   if (!val)
+      return -ENODEV;
+
+   plic->int_nums = fdt32_to_cpu(*val);
+   return 0;
+}
+
+static int
+plic_find_hart_irq_index(void *fdt, int node, int irq_cnt, int hartid)
+{
+   int irq_index, len, rc, intc_node, cpu_node, hwirq, type;
+   const fdt32_t *val;
+   u64 cpuid;
+   struct fdt_irq_param irq_param;
+
+   for (irq_index = 0; irq_index < irq_cnt; irq_index++) {
+      rc = fdt_parse_one_hwirq(fdt, node, irq_index, &irq_param);
+      if (rc)
+         return -EINVAL;
+
+      default_xlate_irq_param(&irq_param, &hwirq, &type, NULL);
+      intc_node = irq_param.intc_node;
+
+      cpu_node = fdt_parent_offset(fdt, intc_node);
+      if (cpu_node < 0)
+         return -EINVAL;
+
+      val = fdt_getprop(fdt, cpu_node, "device_type", &len);
+      if (!val)
+         return -EINVAL;
+
+      if (strncmp ((char *)val, "cpu", strlen ("cpu")))
+         return -EINVAL;
+
+      rc = fdt_get_node_addr_size(fdt, cpu_node, 0, &cpuid, NULL);
+      if (rc)
+         return -EINVAL;
+
+      if ((cpuid == (u64)hartid) && (hwirq == IRQ_S_EXT))
+         return irq_index;
+   }
+
+   return -EINVAL;
+}
+
+static void plic_set_mask(int hwirq, void *priv)
+{
+   struct plic_per_hart *plic_hart;
+   void *enable, *priority;
+   u32 enable_mask;
+
+   plic_hart = (struct plic_per_hart *)priv;
+   priority = plic_hart->priority_base + hwirq * SPRIORITY_PER_ID;
+   enable = plic_hart->enable_base + (hwirq / 32) * sizeof(u32);
+   enable_mask = 1 << (hwirq % 32);
+   mmio_writel(0, priority);
+   mmio_writel(mmio_readl(enable) & ~enable_mask, enable);
+}
+
+static void plic_clear_mask(int hwirq, void *priv)
+{
+   struct plic_per_hart *plic_hart;
+   void *enable, *priority;
+   u32 enable_mask;
+
+   plic_hart = (struct plic_per_hart *)priv;
+   priority = plic_hart->priority_base + hwirq * SPRIORITY_PER_ID;
+   enable = plic_hart->enable_base + (hwirq / 32) * sizeof(u32);
+   enable_mask = 1 << (hwirq % 32);
+   mmio_writel(1, priority);
+   mmio_writel(mmio_readl(enable) | enable_mask, enable);
+}
+
+static bool plic_is_masked(int hwirq, void *priv)
+{
+   struct plic_per_hart *plic_hart;
+   void *enable;
+   u32 enable_mask;
+
+   plic_hart = (struct plic_per_hart *)priv;
+   enable = plic_hart->enable_base + (hwirq / 32) * sizeof(u32);
+   enable_mask = 1 << (hwirq % 32);
+   return !(mmio_readl(enable) & enable_mask);
+}
+
+static enum irq_action plic_irq_handler(void *ctx)
+{
+   enum irq_action hret = IRQ_NOT_HANDLED;
+   struct plic_base *plic;
+   int hwirq, irq;
+   void *claim;
+
+   ASSERT(!are_interrupts_enabled());
+   ASSERT(!is_preemption_enabled());
+
+   plic = (struct plic_base *)ctx;
+   claim = plic->plic_hart.context_base + SCONTEXT_CLAIM;
+
+   /*
+    * Reading and writing claim register automatically enables
+    * and disables the interrupt, nothing else to do.
+    */
+   hwirq = mmio_readl(claim);
+   irq = plic->domain->irq_map[hwirq];
+   ASSERT(irq);
+
+   enable_interrupts_forced();
+   {
+      hret = generic_irq_handler(irq);
+   }
+   disable_interrupts_forced();
+   mmio_writel(hwirq, claim);
+   return hret;
+}
+
+struct fdt_irqchip_ops plic_ops = {
+   .hwirq_set_mask = plic_set_mask,
+   .hwirq_clear_mask = plic_clear_mask,
+   .hwirq_is_masked = plic_is_masked,
+};
+
+DEFINE_IRQ_HANDLER_NODE(plic_irq_node, plic_irq_handler, NULL);
+
+int plic_init(void *fdt, int node, const struct fdt_match *match)
+{
+   int rc, irq, irq_cnt, irq_index;
+   struct plic_base *plic;
+
+   plic = kzalloc_obj(struct plic_base);
+   if (!plic) {
+      printk("plic: ERROR: unable to alloc plic\n");
+      return -ENOMEM;
+   }
+
+   rc = fdt_parse_plic(fdt, node, plic);
+   if (rc)
+      goto bad;
+
+   irq_cnt = irqchip_get_irq_count(fdt, node);
+   if (!irq_cnt) {
+      printk("plic: ERROR: PLIC has no irq!\n");
+      rc = -EINVAL;
+      goto bad;
+   }
+
+   irq_index = plic_find_hart_irq_index(fdt, node, irq_cnt, get_boothartid());
+   if (irq_index < 0) {
+      printk("plic: ERROR: plic_find_hart_irq_index()!\n");
+      rc = -EINVAL;
+      goto bad;
+   }
+
+   plic->domain = irqchip_register_irq_domain(&plic->plic_hart,
+                                              node,
+                                              plic->int_nums,
+                                              &plic_ops);
+   if (!plic->domain) {
+      printk("plic: ERROR: unable to register IRQ domain\n");
+      rc = -EINVAL;
+      goto bad;
+   }
+
+   plic->base = ioremap(plic->paddr, plic->size);
+   if (!plic->base) {
+      printk("plic: ERROR: ioremap failed for %p\n", (void *)plic->paddr);
+      rc = -EIO;
+      goto bad0;
+   }
+
+   plic->plic_hart.hart_id = get_boothartid();
+   plic->plic_hart.irq_index = irq_index;
+   plic->plic_hart.priority_base = plic->base + SPRIORITY_BASE;
+   plic->plic_hart.context_base = plic->base + SCONTEXT_BASE          \
+                                 + get_boothartid() * SCONTEXT_PER_HART * 2;
+   plic->plic_hart.enable_base = plic->base + SENABLE_BASE            \
+                                 + get_boothartid() * SENABLE_PER_HART * 2;
+
+   /* Set hart threshold to zero */
+   mmio_writel(0, plic->plic_hart.context_base + SCONTEXT_THRESHOLD);
+
+   /* Mask all interrupts */
+   for (u32 i = 1; i <= plic->int_nums; i++) {
+      plic_set_mask(i, &plic->plic_hart);
+   }
+
+   /* Alloc a globle irq number */
+   irq = irqchip_alloc_irq(fdt, node, irq_index);
+   if (irq < 0) {
+      printk("plic: ERROR: cannot alloc globle irq number!\n");
+      rc = -EINVAL;
+      goto bad;
+   }
+
+   plic_irq = irq;
+
+   /* setup irq handler */
+   plic_irq_node.context = plic;
+   irq_install_handler(irq, &plic_irq_node);
+   return 0;
+
+bad0:
+   kfree(plic->domain);
+bad:
+   kfree(plic);
+   return rc;
+}
+
+static const struct fdt_match plic_ids[] = {
+   {.compatible = "riscv,plic0"},
+   {.compatible = "sifive,plic-1.0.0"},
+   {.compatible = "thead,c900-plic"},
+   { }
+};
+
+REGISTER_FDT_IRQCHIP(plic, plic_ids, plic_init)
 


### PR DESCRIPTION
Hi @vvaltchev 

This framework implements concepts similar to linux interrupt domains. The framework resolves the dependencies of interrupt controllers in the device tree and initializes them in order; Peripherals do not need to worry about the interrupt hardware connection when they request an interrupt, the framework will take care of these problems according to the device tree; And the interrupt number is dynamically assigned.
On a typical embedded chip, the number of interrupt controllers is relatively large, and there may be more than three levels of connection between interrupt controllers (such as “intc->plic->gpio->peripherals” on riscv). Therefore, we must use a more flexible approach to management interrupt, rather than using hard-coded interrupt numbers like x86.
