### PR TITLE
[sched] Improve running_in_kernel

### DIFF
--- a/include/tilck/kernel/arch/i386/asm_defs.h
+++ b/include/tilck/kernel/arch/i386/asm_defs.h
@@ -14,8 +14,8 @@
    #error Unsupported value of KERNEL_STACK_PAGES
 #endif
 
-#define TI_F_RESUME_RS_OFF     20 /* offset of: fault_resume_regs */
-#define TI_FAULTS_MASK_OFF     24 /* offset of: faults_resume_mask */
+#define TI_F_RESUME_RS_OFF     24 /* offset of: fault_resume_regs */
+#define TI_FAULTS_MASK_OFF     28 /* offset of: faults_resume_mask */
 
 #define SIZEOF_REGS            84
 #define REGS_EIP_OFF           64

--- a/include/tilck/kernel/arch/riscv/asm_defs.h
+++ b/include/tilck/kernel/arch/riscv/asm_defs.h
@@ -14,8 +14,8 @@
    #error Unsupported value of KERNEL_STACK_PAGES
 #endif
 #if __riscv_xlen == 64
-   #define TI_F_RESUME_RS_OFF     32 /* offset of: fault_resume_regs */
-   #define TI_FAULTS_MASK_OFF     40 /* offset of: faults_resume_mask */
+   #define TI_F_RESUME_RS_OFF     40 /* offset of: fault_resume_regs */
+   #define TI_FAULTS_MASK_OFF     48 /* offset of: faults_resume_mask */
 #else
    #define TI_F_RESUME_RS_OFF     20 /* TODO: riscv32 */
    #define TI_FAULTS_MASK_OFF     24 /* TODO: riscv32 */

--- a/include/tilck/kernel/sched.h
+++ b/include/tilck/kernel/sched.h
@@ -13,6 +13,8 @@
 
 #include <tilck_gen_headers/config_sched.h>
 
+#define IN_SYSCALL_FLAG (1u << 31)
+
 enum task_state {
    TASK_STATE_INVALID   = 0,
    TASK_STATE_RUNNABLE  = 1,
@@ -62,8 +64,8 @@ struct task {
 
    struct process *pi;
 
+   u32 running_in_kernel;
    bool is_main_thread;                      /* value of `tid == pi->pid` */
-   bool running_in_kernel;
    bool stopped;
    bool was_stopped;
 
@@ -212,7 +214,11 @@ static ALWAYS_INLINE bool is_preemption_enabled(void)
 
 static ALWAYS_INLINE bool running_in_kernel(struct task *t)
 {
-   return t->running_in_kernel;
+   return !!t->running_in_kernel;
+}
+
+static ALWAYS_INLINE bool in_syscall(struct task *t) {
+   return t->running_in_kernel & IN_SYSCALL_FLAG;
 }
 
 static ALWAYS_INLINE bool is_kernel_thread(struct task *ti)

--- a/include/tilck/kernel/switch.h
+++ b/include/tilck/kernel/switch.h
@@ -13,7 +13,7 @@ switch_to_task_pop_nested_interrupts(void)
 
       ASSERT(get_curr_task() != NULL);
 
-      if (get_curr_task()->running_in_kernel)
+      if (in_syscall(get_curr_task()))
          if (!is_kernel_thread(get_curr_task()))
             nested_interrupts_drop_top_syscall();
    }

--- a/kernel/arch/i386/paging.c
+++ b/kernel/arch/i386/paging.c
@@ -86,7 +86,7 @@ bool handle_potential_cow(void *context)
       // Out-of-memory case
       struct task *curr = get_curr_task();
 
-      if (!curr->running_in_kernel) {
+      if (!in_syscall(curr)) {
 
          // The task was not running in kernel: we can safely kill it.
          printk("Out-of-memory: killing pid %d\n", get_curr_pid());

--- a/kernel/arch/i386/process32.c
+++ b/kernel/arch/i386/process32.c
@@ -219,9 +219,9 @@ switch_to_task(struct task *ti)
    enable_preemption_nosched();
    ASSERT(is_preemption_enabled());
 
-   if (!ti->running_in_kernel)
+   if (!running_in_kernel(ti))
       task_info_reset_kernel_stack(ti);
-   else
+   else if (in_syscall(ti))
       adjust_nested_interrupts_for_task_in_kernel(ti);
 
    set_curr_task(ti);

--- a/kernel/arch/riscv/cpu.c
+++ b/kernel/arch/riscv/cpu.c
@@ -25,7 +25,7 @@ static void handle_inst_illegal_fpu_fault(regs_t *r)
    struct task *curr = get_curr_task();
    const int int_num = r->int_num;
 
-   if (is_kernel_thread(curr) || running_in_kernel(curr))
+   if (is_kernel_thread(curr) || in_syscall(curr))
       goto normal_illegal_fault;
 
    if (r->sstatus & SR_FS)

--- a/kernel/arch/riscv/paging.c
+++ b/kernel/arch/riscv/paging.c
@@ -110,7 +110,7 @@ bool handle_potential_cow(void *context)
       // Out-of-memory case
       struct task *curr = get_curr_task();
 
-      if (curr->running_in_kernel) {
+      if (in_syscall(curr)) {
 
          // We cannot kill a task running in kernel during a CoW page fault
          // In this case (but in the one above too), Linux puts the process to

--- a/kernel/arch/riscv/process_riscv.c
+++ b/kernel/arch/riscv/process_riscv.c
@@ -148,8 +148,9 @@ switch_to_task(struct task *ti)
          set_curr_pdir(ti->pi->pdir);
       }
 
-      if (!ti->running_in_kernel && !(state->sstatus & SR_SPP))
+      if (!running_in_kernel(ti)) {
          process_signals(ti, sig_in_usermode, state);
+      }
 
       if (is_fpu_enabled_for_task(ti)) {
          restore_fpu_regs(ti, false);
@@ -162,9 +163,9 @@ switch_to_task(struct task *ti)
    enable_preemption_nosched();
    ASSERT(is_preemption_enabled());
 
-   if (!ti->running_in_kernel)
+   if (!running_in_kernel(ti))
       task_info_reset_kernel_stack(ti);
-   else
+   else if (in_syscall(ti))
       adjust_nested_interrupts_for_task_in_kernel(ti);
 
    set_curr_task(ti);

--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -100,7 +100,7 @@ int do_fork(regs_t *user_regs, bool vfork)
    ASSERT(child->kernel_stack != NULL);
 
    child->state = TASK_STATE_RUNNABLE;
-   child->running_in_kernel = false;
+   child->running_in_kernel = 0;
    task_info_reset_kernel_stack(child);
 
    ASSERT(curr != NULL);

--- a/kernel/interrupts.c
+++ b/kernel/interrupts.c
@@ -263,6 +263,7 @@ void fault_entry(regs_t *r)
     */
    ASSERT(!are_interrupts_enabled());
 
+   get_curr_task()->running_in_kernel++;
    push_nested_interrupt(regs_intnum(r));
    disable_preemption();
    enable_interrupts_forced();
@@ -275,10 +276,11 @@ void fault_entry(regs_t *r)
     */
    pop_nested_interrupt();
 
-   if (!get_curr_task()->running_in_kernel)
+   if (!in_syscall(get_curr_task()))
       process_signals(get_curr_task(), sig_in_fault, r);
 
    enable_preemption();
    disable_interrupts_forced();
+   get_curr_task()->running_in_kernel--;
 }
 

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -761,7 +761,7 @@ finalize_usermode_task_setup(struct task *ti, regs_t *user_regs)
    ASSERT_TASK_STATE(ti->state, TASK_STATE_RUNNING);
    task_change_state(ti, TASK_STATE_RUNNABLE);
 
-   ti->running_in_kernel = false;
+   ti->running_in_kernel = 0;
    ASSERT(ti->kernel_stack != NULL);
 
    task_info_reset_kernel_stack(ti);
@@ -932,7 +932,7 @@ kthread_create2(kthread_func_ptr func, const char *name, int fl, void *arg)
 
    ti->kthread_name = name;
    ti->state = TASK_STATE_RUNNABLE;
-   ti->running_in_kernel = true;
+   ti->running_in_kernel = IN_SYSCALL_FLAG;
    task_info_reset_kernel_stack(ti);
    kthread_create_setup_initial_stack(ti, &r, arg);
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -410,7 +410,7 @@ static void create_kernel_process(void)
    init_process_lists(s_kernel_pi);
 
    s_kernel_ti->is_main_thread = true;
-   s_kernel_ti->running_in_kernel = true;
+   s_kernel_ti->running_in_kernel = IN_SYSCALL_FLAG;
    memcpy(s_kernel_pi->str_cwd, "/", 2);
 
    s_kernel_ti->state = TASK_STATE_SLEEPING;
@@ -461,7 +461,7 @@ void init_sched(void)
 void set_current_task_in_kernel(void)
 {
    ASSERT(!is_preemption_enabled());
-   get_curr_task()->running_in_kernel = true;
+   get_curr_task()->running_in_kernel |= IN_SYSCALL_FLAG;
 }
 
 static void task_add_to_state_list(struct task *ti)

--- a/kernel/switch.c
+++ b/kernel/switch.c
@@ -211,7 +211,7 @@ set_current_task_in_user_mode(void)
    ASSERT(!is_preemption_enabled());
    struct task *curr = get_curr_task();
 
-   curr->running_in_kernel = false;
+   curr->running_in_kernel &= ~((u32)IN_SYSCALL_FLAG);
    task_info_reset_kernel_stack(curr);
 
 #if defined(__i386__)


### PR DESCRIPTION
Hi @vvaltchev 

As we discussed in #201, here is a proposal for improve the running_in_kernel.

Make `running_in_kernel` a bit-field variable, with the highest bit indicating weather we are in a syscall and low bits for fault count.


