### PR TITLE
[kmalloc] Check if internal_kmalloc() returns NULL

### DIFF
--- a/kernel/kmalloc/kmalloc.c
+++ b/kernel/kmalloc/kmalloc.c
@@ -503,6 +503,9 @@ per_heap_kmalloc_unsafe(struct kmalloc_heap *h, size_t *size, u32 flags)
                               true,              /* mark node as allocated */
                               do_actual_alloc);
 
+      if (!addr)
+         return NULL;
+
       ASSERT(addr == big_block + tot);
 
       if (sub_blocks_min_size) {


### PR DESCRIPTION
@vvaltchev 

Here seem to have forgotten to consider the case where `internal_kmalloc()` returns NULL.
If `internal_kmalloc()` returns NULL, just return NULL in per_heap_kmalloc_unsafe().

```
   void *big_block =
      internal_kmalloc(h, rounded_up_size, 0, h->size, false, false);

   if (!big_block)    //<<<<<<<<<<<<<<<<<<<<<here takes into account the case where internal_kmalloc returns NULL
      return NULL;

   const int big_block_node = ptr_to_node(h, big_block, rounded_up_size);
   size_t tot = 0;

   for (int i=(int)h->heap_data_size_log2-1; i >= 0 && tot < desired_size; i--)
   {
      const size_t s = (1u << i);

      if (!(desired_size & s))
         continue;

      addr = internal_kmalloc(h,
                              s,
                              big_block_node,
                              rounded_up_size,
                              true,              /* mark node as allocated */
                              do_actual_alloc);

      ASSERT(addr == big_block + tot);       //<<<<<<<<<<<<<<<<<<<<<if internal_kmalloc() just returns NULL, the ASSERT will be triggered！
```
