### PR TITLE
[riscv] fix NOCOW pdir_deep_clone()

### DIFF
--- a/kernel/arch/riscv/paging.c
+++ b/kernel/arch/riscv/paging.c
@@ -693,8 +693,11 @@ pdir_clone_int(pdir_t *old_pdir,pdir_t *new_pdir,
          }
       }
 
-      // copy the page table
-      memcpy(new_pdir, old_pdir, sizeof(page_table_t));
+      if (!deep) {
+         // copy the page table
+         memcpy(new_pdir, old_pdir, sizeof(page_table_t));
+      }
+
       return 0;
    }
 


### PR DESCRIPTION
Now riscv64 NOCOW build should work correctly.
