### PR TITLE
[riscv] fix fault_resumable_call() when returned from fault

### DIFF
--- a/kernel/arch/riscv/fault_resumable.S
+++ b/kernel/arch/riscv/fault_resumable.S
@@ -108,6 +108,8 @@ FUNC(fault_resumable_call):
 
 .asm_fault_resumable_call_resume:
 
+   REG_L a0, 10 * RISCV_SZPTR(sp)    # extracted a0 value which
+                                     # set in handle_resumable_fault()
    resume_callee_regs
 
    la t0, __current


### PR DESCRIPTION
Extracted a0 value which set in `handle_resumable_fault()` when returned from a fault.
This place can cause exceptions very occasionally.

Btw, when these bugs mentioned by these PRs are fixed, riscv64 should at least be able to run runall tests stably for a long time.
