### PR TITLE
[riscv] refactor init_early_mapping()

### DIFF
--- a/kernel/arch/riscv/early_fdt.c
+++ b/kernel/arch/riscv/early_fdt.c
@@ -354,8 +354,11 @@ static int fdt_parse_framebuffer(void *fdt)
 
    for (int i = 0; i < ARRAY_SIZE(simplefb_formats); i++) {
 
-      if (strcmp((void *)prop, simplefb_formats[i].name))
+      if (strcmp((void *)prop,
+            (void *)KERNEL_VA_TO_PA(simplefb_formats[i].name)))
+      {
          continue;
+      }
 
       format = &simplefb_formats[i];
       mbi->framebuffer_bpp = format->bpp;

--- a/kernel/arch/riscv/start.S
+++ b/kernel/arch/riscv/start.S
@@ -97,10 +97,15 @@ clear_bss_done:
    call sbi_init
 
    mv a0, s1
-   call init_early_mapping
+   call prepare_early_mapping
 
    call parse_fdt
    mv s2, a0   /* Save multiboot info structure physical address */
+
+   call early_get_cpu_features
+
+   mv a0, s1
+   call init_early_mapping
 
    la a0, page_size_buf
    li a1, SATP_MODE
@@ -122,8 +127,6 @@ clear_bss_done:
    ret
 
 .next_step:
-
-   call early_get_cpu_features
 
    /* Enable access to user memory */
    li t0, SR_SUM


### PR DESCRIPTION
`early_get_cpu_features()` must be down even before `init_early_mapping()` (before virtual memory is enabled)