### PR TITLE
[riscv64][bsp] support sipeed licheerv-nano board

### DIFF
--- a/other/bsp/riscv64/licheerv-nano/board_bsp.cmake
+++ b/other/bsp/riscv64/licheerv-nano/board_bsp.cmake
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: BSD-2-Clause
+cmake_minimum_required(VERSION 3.22)
+
+macro(get_cvi_board_memmap)
+
+   file(
+      STRINGS ${BOARD_MEMMAP_FILE} ${ARGV0}_STR
+      REGEX "^CVIMMAP_${ARGV0}=.*$"
+   )
+
+   message(STATUS "${ARGV0}_STR orig: ${${ARGV0}_STR}")
+
+   string(
+      REGEX REPLACE "^CVIMMAP_${ARGV0}=0x(.*)$" "\\1"
+      ${ARGV0}_STR ${${ARGV0}_STR}
+   )
+
+   message(STATUS "${ARGV0}_STR replace: ${${ARGV0}_STR}")
+
+   set(${ARGV0} 0x${${ARGV0}_STR})
+
+   message(STATUS "${ARGV0}: ${${ARGV0}}")
+
+endmacro()
+
+set(
+   BOARD_MEMMAP_FILE
+   "${TCROOT}/${ARCH}/bootloader/build/output/sg2002_licheervnano_sd/\
+cvi_board_memmap.conf"
+)
+
+# Get the uimage address, which will be used for boot scripts
+get_cvi_board_memmap(UIMAG_ADDR)
+
+set(
+   BOARD_BSP_BOOTLOADER
+   ${TCROOT}/${ARCH}/bootloader/install/soc_sg2002_licheervnano_sd/fip.bin
+)
+
+set(BOARD_BSP_MKIMAGE
+   "${TCROOT}/${ARCH}/bootloader/u-boot-2021.10/build/sg2002_licheervnano_sd/\
+tools/mkimage"
+)
+
+set(
+   BOARD_DTB_FILE
+   "${TCROOT}/${ARCH}/bootloader/u-boot-2021.10/build/sg2002_licheervnano_sd/\
+arch/riscv/dts/sg2002_licheervnano_sd.dtb"
+)
+
+set(KERNEL_PADDR                  0x80200000)
+
+# Parameters required by boot script of u-boot
+math(EXPR KERNEL_ENTRY "${KERNEL_PADDR} + 0x1000"
+      OUTPUT_FORMAT HEXADECIMAL)
+math(EXPR KERNEL_LOAD "${UIMAG_ADDR} - 0x800000"
+      OUTPUT_FORMAT HEXADECIMAL)
+
+# licheerv-nano do not have a rtc
+set(KRN_CLOCK_DRIFT_COMP OFF CACHE BOOL
+    "Compensate periodically for the clock drift in the system time" FORCE)
+

--- a/other/bsp/riscv64/licheerv-nano/bootloader
+++ b/other/bsp/riscv64/licheerv-nano/bootloader
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-2-Clause
+
+function internal_build_bootloader {
+
+   echo "Building bootloader... "
+   reset_cc_vars_to_null
+
+   set +e
+   run_command2 "source build/cvisetup.sh" build.log
+   run_command2 "defconfig sg2002_licheervnano_sd" build.log
+   run_command2 "build_uboot" build.log
+   set -e
+}
+
+#
+# Note: patch the fsbl/plat/sg200x/bl2/bl2_main.c to set the uart baudrate to
+# 115200. Otherwise, a hardware error may occur in the uart after the chip
+# is reset, and this error will cause the uart to interrupt continuously.
+#
+function bootloader_patch {
+
+   old1="if (v == BOOT_SRC_UART)"
+   new1="if (v == BOOT_SRC_SD)"
+   old2="console_init(0, PLAT_UART_CLK_IN_HZ, UART_DL_BAUDRATE)"
+   new2="console_init(0, 25804800, 115200)"
+
+   file="fsbl/plat/sg200x/bl2/bl2_main.c"
+   if ! [ -f $file ]; then
+      echo "ERROR: file $file not found!"
+      exit 1
+   fi
+   run_command "sed -i 's/${old1}/${new1}/' $file"
+   run_command "sed -i 's/${old2}/${new2}/' $file"
+}
+
+all_funcs_list+=(build_bootloader)
+function build_bootloader {
+
+   pushd $ARCH
+
+   if ! [ -d bootloader ]; then
+
+      show_work_on_component_msg "bootloader"
+
+      local url="https://github.com/sipeed/LicheeRV-Nano-Build/archive/refs/tags"
+      local ver="20240726"
+      local tarname=$ver.tar.gz
+
+      download_file_in_cache "$url" "$tarname"
+      extract_cachefile_tar_gz $tarname LicheeRV-Nano-Build-$ver bootloader
+
+      pushd bootloader
+
+      url="https://github.com/sophgo/host-tools/archive/refs/tags"
+      ver="1.6"
+      tarname=$ver.tar.gz
+
+      download_file_in_cache "$url" "$tarname"
+      extract_cachefile_tar_gz $tarname host-tools-$ver host-tools
+
+      bootloader_patch
+      (internal_build_bootloader)
+
+      local fip_bin="install/soc_sg2002_licheervnano_sd/fip.bin"
+      if ! [ -f $TC/$ARCH/bootloader/$fip_bin ]; then
+         echo "ERROR: build failed !!!" >> build.log
+         exit 1
+      fi
+
+      popd
+
+   elif [ "$REBUILD" == "1" ]; then
+
+      pushd bootloader
+      (internal_build_bootloader)
+      popd
+
+   else
+      show_skip_component_msg "bootloader"
+   fi
+
+   popd
+}
+
+function build_bootloader_installed_status {
+
+   local arch_list=""
+   local fip_bin="install/soc_sg2002_licheervnano_sd/fip.bin"
+   for x in $ALL_ARCH_LIST; do
+      if [ -d $TC/$x/bootloader ]; then
+         if [ -f $TC/$x/bootloader/$fip_bin ]; then
+            arch_list="${arch_list}$x "
+         else
+            echo "error"
+            return
+         fi
+      fi
+   done
+
+   # Drop the trailing " "
+   if [[ "${arch_list: -1}" == " " ]]; then
+      arch_list="${arch_list:: -1}"
+   fi
+
+   if [ -n "$arch_list" ]; then
+      echo "installed $arch_list"
+   fi
+}

--- a/other/bsp/riscv64/licheerv-nano/fit-image.its
+++ b/other/bsp/riscv64/licheerv-nano/fit-image.its
@@ -1,0 +1,54 @@
+/dts-v1/;
+
+/ {
+   description = "U-boot FIT image for licheerv-nano";
+   #address-cells = <2>;
+
+   images {
+      tilck {
+         description = "tilck";
+         data = /incbin/("@KERNEL_FILE@");
+         type = "kernel";
+         arch = "riscv";
+         os = "linux";
+         load = <0x0 @KERNEL_LOAD@>;
+         entry = <0x0 @KERNEL_ENTRY@>;
+         compression = "none";
+      };
+
+      ramdisk {
+         description = "buildroot initramfs";
+         data = /incbin/("@CMAKE_BINARY_DIR@/fatpart");
+         type = "ramdisk";
+         arch = "riscv";
+         os = "linux";
+         load = <0x0 0x0>;
+         compression = "none";
+         hash-1 {
+            algo = "sha256";
+         };
+      };
+
+      fdt {
+          description = "licheerv-nano device tree";
+          data = /incbin/("@BOARD_DTB_FILE@");
+          type = "flat_dt";
+          arch = "riscv";
+          compression = "none";
+          hash-1 {
+              algo = "sha256";
+          };
+      };
+   };
+
+   configurations {
+      default = "config-1";
+
+      config-1 {
+         description = "qemu-riscv64";
+         kernel = "tilck";
+         ramdisk = "ramdisk";
+         fdt = "fdt";
+      };
+   };
+};

--- a/other/bsp/riscv64/licheerv-nano/u-boot.cmd
+++ b/other/bsp/riscv64/licheerv-nano/u-boot.cmd
@@ -1,0 +1,1 @@
+echo licheerv-nano bsp

--- a/other/bsp/riscv64/licheerv-nano/uEnv.txt
+++ b/other/bsp/riscv64/licheerv-nano/uEnv.txt
@@ -1,0 +1,41 @@
+# This is the sample uEnv.txt file for licheerv-nano U-boot
+
+# Select LCD model
+# Default LCD is for MaixCAM
+panel=st7701_hd228001c31
+
+# kernel command line can be modified here
+bootargs=tilck -sercon -panic_regs -panic_mmap -panic_kb
+
+# When bootelf kernel, do not directly jump into kernel, bootelf is only used
+# to properly load tilck in elf format.
+# After bootelf, we use a 'bootm go' to jump into kernel, because boom can
+# pass the device tree pointer and boothart accurately to kernel.
+autostart=no
+
+# no need to relocate initrd
+# initrd_high=ffffffffffffffff
+
+# The FIT file to boot from
+fitfile=image.fit
+
+# kerneladdr must match what's in FIT
+# Note: loading kernel is divided into two steps
+# 1. The bootm loados command loads the kernel into kerneladdr(@KERNEL_LOAD@ which
+#       is defined in fit-image.its)
+# 2. The bootelf -p command loads the kernel into 0x80200000(the
+#      load address defined by the elf header)
+kerneladdr=@KERNEL_LOAD@
+
+# load fit image from fatpart
+loadfit=echo Boot from SD dev ${sddev} ...;mmc dev ${sddev} && fatload mmc ${sddev}:2 ${uImage_addr} ${fitfile};
+
+# load kernel and initrd into ram
+loadkernel=bootm start ${uImage_addr}; bootm loados ${uImage_addr}; bootm ramdisk ${uImage_addr}; bootelf -p ${kerneladdr}; bootm prep ${uImage_addr};
+
+# just for debug
+message=echo bootm go ...;echo ${bootargs};
+
+# the real boot command be executed
+sdboot=run loadfit; run loadkernel; run message; bootm go ${uImage_addr};
+


### PR DESCRIPTION
Hi @vvaltchev,

This PR add support for Sipeed licheerv-nano core board ( _https://wiki.sipeed.com/hardware/en/lichee/RV_Nano/1_intro.html_ )

**BSP usage:**
under tilck project:

1. Make image
```
export ARCH=riscv64
export BOARD=licheerv-nano
./scripts/build_toolchain
make
```
2. Then flash `build/tilck.img` into a microSD card;
3. Insert the microsd card into the card slot on the licheerv-nano board;
4. Connect uart0 on the board (baudrate 115200), and power on the board.
5. Have fun!

boot log:
```
FSBL zIXgg9:g605e5cb6-dirty:2024-08-19T16:32:39+08:00
st_on_reason=d0000
st_off_reason=0
P2S/0x1000/0xc00a200.
SD/0x9200/0x1000/0x1000/0.P2E.
DPS/0xa200/0x2000.
SD/0xa200/0x2000/0x2000/0.DPE.
cv181x DDR init.
ddr_param[0]=0x78075562.
pkg_type=5
D1_3_2
DDR3-2G-QFN
Data rate=1866.
DDR BIST PASS
PLLS.
PLLE.
C2S/0x0/0x0/0x0.
No C906L image.
MS/0xc200/0x80000000/0x1c000.
SD/0xc200/0x1c000/0x1c000/0.ME.
L2/0x28200.
SD/0x28200/0x200/0x200/0.L2/0x414d3342/0xcafe44a4/0x80200000/0x43400/0x43400
COMP/1.
SD/0x28200/0x43400/0x43400/0.DCP/0x80200020/0x1000000/0x81900020/0x43400/1.
DCP/0x9027e/0.
Loader_2nd loaded.
Use internal 32k
Jump to monitor at 0x80000000.
OPENSBI: next_addr=0x80200020 arg1=0x80080000
OpenSBI v0.9
   ____                    _____ ____ _____
  / __ \                  / ____|  _ \_   _|
 | |  | |_ __   ___ _ __ | (___ | |_) || |
 | |  | | '_ \ / _ \ '_ \ \___ \|  _ < | |
 | |__| | |_) |  __/ | | |____) | |_) || |_
  \____/| .__/ \___|_| |_|_____/|____/_____|
        | |
        |_|

Platform Name             : LicheeRv Nano
Platform Features         : mfdeleg
Platform HART Count       : 1
Platform IPI Device       : clint
Platform Timer Device     : clint
Platform Console Device   : uart8250
Platform HSM Device       : ---
Platform SysReset Device  : ---
Firmware Base             : 0x80000000
Firmware Size             : 136 KB
Runtime SBI Version       : 0.3

Domain0 Name              : root
Domain0 Boot HART         : 0
Domain0 HARTs             : 0*
Domain0 Region00          : 0x0000000074000000-0x000000007400ffff (I)
Domain0 Region01          : 0x0000000080000000-0x000000008003ffff ()
Domain0 Region02          : 0x0000000000000000-0xffffffffffffffff (R,W,X)
Domain0 Next Address      : 0x0000000080200020
Domain0 Next Arg1         : 0x0000000080080000
Domain0 Next Mode         : S-mode
Domain0 SysReset          : yes

Boot HART ID              : 0
Boot HART Domain          : root
Boot HART ISA             : rv64imafdcvsux
Boot HART Features        : scounteren,mcounteren,time
Boot HART PMP Count       : 16
Boot HART PMP Granularity : 4096
Boot HART PMP Address Bits: 38
Boot HART MHPM Count      : 8
Boot HART MHPM Count      : 8
Boot HART MIDELEG         : 0x0000000000000222
Boot HART MEDELEG         : 0x000000000000b109


U-Boot 2021.10 (Aug 19 2024 - 16:32:34 +0800) soph

DRAM:  254 MiB
gd->relocaddr=0x8a834000. offset=0xa634000
MMC:   cv-sd@4310000: 0, wifi-sd@4320000: 1
Loading Environment from nowhere... OK
In:    serial
Out:   serial
Err:   serial
Net:   
Warning: ethernet@4070000 (eth0) using random MAC address - 76:d7:32:1b:5a:06
eth0: ethernet@4070000
Hit any key to stop autoboot:  0 
Device: cv-sd@4310000
Manufacturer ID: 3
OEM: 5344
Name: SK32G
Bus Speed: 25000000
Mode: SD High Speed (50MHz)
Rd Block Len: 512
SD version 3.0
High Capacity: Yes
Capacity: 29.7 GiB
Bus Width: 4-bit
Erase Group Size: 512 Bytes
1459 bytes read in 2 ms (711.9 KiB/s)
## Warning: defaulting to text format
## Info: input data size = 181706 = 0x2C5CA
switch to partitions #0, OK
mmc0 is current device
** Unable to read file logo.jpeg **
Failed to load 'logo.jpeg'

start jpeg dec task!, bs_addr 0000000084080000, yuv_addr 000000008ab30000, size 524288
[ERR] JpegDecodeHeader = 1307, DONE_DEC_HEADER
[ERR] JpegDecodeHeader = 1439, fail
[ERR] JPU_DecGetInitialInfo = 209, JpegDecodeHeader
jpeg_decode_helper = 251, JPU_DecGetInitialInfo failed Error code is 0x1, inst=0
cvi_vo_probe: Warning: cannot get power GPIO: ret=-2
Init panel ST7701-368x552
dm_gpio_set_value(disp_power_ct_gpio, deassert) failed: -2Boot from SD dev 0 ...
switch to partitions #0, OK
mmc0 is current device
2063216 bytes read in 184 ms (10.7 MiB/s)
## Loading kernel from FIT Image at 81800000 ...
   Using 'config-1' configuration
   Trying 'tilck' kernel subimage
     Description:  tilck
     Type:         Kernel Image
     Compression:  uncompressed
     Data Start:   0x818000c8
     Data Size:    830224 Bytes = 810.8 KiB
     Architecture: RISC-V
     OS:           Linux
     Load Address: 0x81000000
     Entry Point:  0x80201000
   Verifying Hash Integrity ... OK
## Loading ramdisk from FIT Image at 81800000 ...
   Using 'config-1' configuration
   Trying 'ramdisk' ramdisk subimage
     Description:  buildroot initramfs
     Type:         RAMDisk Image
     Compression:  uncompressed
     Data Start:   0x818cac8c
     Data Size:    1205248 Bytes = 1.1 MiB
     Architecture: RISC-V
     OS:           Linux
     Load Address: 0x00000000
     Entry Point:  unavailable
     Hash algo:    sha256
     Hash value:   2c5f5f49cf51d2cd4314bbf0c8bc2254656daab7f0c7721e4eb758fd34ecff9a
   Verifying Hash Integrity ... sha256+ OK
## Loading fdt from FIT Image at 81800000 ...
   Using 'config-1' configuration
   Trying 'fdt' fdt subimage
     Description:  licheerv-nano device tree
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x819f1180
     Data Size:    25790 Bytes = 25.2 KiB
     Architecture: RISC-V
     Hash algo:    sha256
     Hash value:   d24e7fe9463ae1ccf00f48be451247d2d7b090817a10833df811c1df542c6499
   Verifying Hash Integrity ... sha256+ OK
   Booting using the fdt blob at 0x819f1180
   Loading Kernel Image
   Decompressing 830224 bytes used 0ms
   Loading Ramdisk to 89dc5000, end 89eeb400 ... OK
   Loading Device Tree to 0000000089dbb000, end 0000000089dc44bd ... OK
bootm go ...
tilck -sercon -panic_regs -panic_mmap -panic_kb

Starting kernel ...

[    0.000] kernel base va:    0x0000002000000000
[    0.000] kernel vaddr:      0x0000002000200000
[    0.000] base va:           0x0000002000000000
[    0.000] linear mapping:    896 MB
[    0.000] 
[    0.000] System memory map from multiboot:
[    0.000] 
[    0.000]            START                 END        (T, Extr)
[    0.000] 00) 0x0000000080000000 - 0x000000008003ffff (2,     ) [     256 KB]
[    0.000] 01) 0x0000000080040000 - 0x00000000800fffff (1,     ) [     768 KB]
[    0.000] 02) 0x0000000080100000 - 0x00000000801fffff (2, LMRS) [    1024 KB]
[    0.000] 03) 0x0000000080200000 - 0x000000008031afff (2, KRNL) [    1132 KB]
[    0.000] 04) 0x000000008031b000 - 0x0000000089dc4fff (1,     ) [  158376 KB]
[    0.000] 05) 0x0000000089dc5000 - 0x0000000089eebfff (2, RDSK) [    1180 KB]
[    0.000] 06) 0x0000000089eec000 - 0x000000008fdfffff (1,     ) [   97360 KB]
[    0.000] 
[    0.000] Kernel cmdline: 'tilck -sercon -panic_regs -panic_mmap -panic_kb'
[    0.000] MODEL: LicheeRv Nano
[    0.000] VENDOR-ID: 0x5b7 ARCH-ID: 0x0 IMP-ID: 0x0
[    0.000] CPU: rv64imafdvcsu
[    0.000] isa-extensions: i m a f d c v 
[    0.000] *** Init the kernel console
[    0.000] *** Init the kernel timer
[    0.108] Tilck bogoMips: 212.400
[    0.108] *** Init kernel module: sysfs
[    0.116] *** Init kernel module: tracing
[    0.124] *** Init kernel module: tty
[    0.128] *** Init kernel module: fb
[    0.132] *** Init kernel module: serial
[    0.136] *** Init kernel module: fdt_serial
[    0.176] *** Init kernel module: systests
[    0.180] Module systests initialized
[    0.184] *** Init kernel module: debugpanel
[    0.188] Hello from Tilck 0.1.4, commit: 605e5cb6 (dirty)
[    0.196] Build type: Debug, compiler: gcc 12.3.0
[    0.204] timer_hz: 250; time_slice: 40 ms; in_hypervisor: no
                    
                    ▒▒▒▒▒▒▒▒┐ ▒▒┐ ▒▒┐       ▒▒▒▒▒▒┐ ▒▒┐  ▒▒┐
                    └──▒▒┌──┘ ▒▒│ ▒▒│      ▒▒┌────┘ ▒▒│ ▒▒┌┘
                       ▒▒│    ▒▒│ ▒▒│      ▒▒│      ▒▒▒▒▒┌┘ 
                       ▒▒│    ▒▒│ ▒▒│      ▒▒│      ▒▒┌─▒▒┐ 
                       ▒▒│    ▒▒│ ▒▒▒▒▒▒▒┐ └▒▒▒▒▒▒┐ ▒▒│  ▒▒┐
                       └─┘    └─┘ └──────┘  └─────┘ └─┘  └─┘
                    
root@tilck:/# 
```


**About framebuffer**
The bootloader released by the original manufacturer contains the driver of the video system, which can be used to display the boot logo. Unfortunately, this driver only supports YUV420 format framebuffer, and tilck has no support for YUV format. Therefore, if you want to enable tilck's framebuffer function, you need to modify the original bootloader source code, and setup the LCD model in the uEnv.txt, and the boot logo is a 24bit bmp file named 'logo.bmp' in boot part of image.
patchfile:
```
diff --git a/build/boards/sg200x/sg2002_licheervnano_sd/u-boot/sg2002_licheervnano_sd_defconfig b/build/boards/sg200x/sg2002_licheervnano_sd/u-boot/sg2002_licheervnano_sd_defconfig
index daa3e5231..699884822 100644
--- a/build/boards/sg200x/sg2002_licheervnano_sd/u-boot/sg2002_licheervnano_sd_defconfig
+++ b/build/boards/sg200x/sg2002_licheervnano_sd/u-boot/sg2002_licheervnano_sd_defconfig
@@ -9,7 +9,8 @@ CONFIG_TARGET_CVITEK_CV181X=y
 CONFIG_DISTRO_DEFAULTS=y
 CONFIG_FIT=y
 # CONFIG_ARCH_FIXUP_FDT_MEMORY is not set
-CONFIG_BOOTDELAY=0
+CONFIG_BOOTDELAY=2
+CONFIG_OF_BOARD_SETUP=y
 CONFIG_SYS_PROMPT="soph# "
 # CONFIG_CMD_CONSOLE is not set
 # CONFIG_CMD_XIMG is not set
diff --git a/u-boot-2021.10/cmd/cvi_vo.c b/u-boot-2021.10/cmd/cvi_vo.c
index 3c12eef28..847b0a0f3 100644
--- a/u-boot-2021.10/cmd/cvi_vo.c
+++ b/u-boot-2021.10/cmd/cvi_vo.c
@@ -8,6 +8,7 @@
 #include <common.h>
 #include <log.h>
 #include <stdlib.h>
+#include <fdt_support.h>
 #include <linux/delay.h>
 #include <cpu_func.h>
 #include <cvi_disp.h>
@@ -300,6 +301,25 @@ U_BOOT_CMD(stopvo
 	, "    - stopvo [dev]"
 );
 
+int ft_board_setup(void *fdt, struct bd_info *bd)
+{
+	int offset;
+	u64 start, size;
+	struct sclr_disp_cfg *cfg;
+
+	offset = fdt_add_subnode(fdt, 0, "simplefb");
+	if (offset < 0)
+		return -1;
+
+	fdt_setprop_string(fdt, offset, "compatible", "simple-framebuffer");
+
+	cfg = sclr_disp_get_cfg();
+	start = cfg->mem.addr0;
+	size = cfg->mem.addr1 - cfg->mem.addr0;
+
+	return fdt_setup_simplefb_node(fdt, offset, start, cfg->mem.width, cfg->mem.height, cfg->mem.pitch_y, "r8g8b8");
+}
+
 /***************************************************/
 static int do_startvl(struct cmd_tbl *cmdtp, int flag, int argc, char * const argv[])
 {
@@ -343,12 +363,49 @@ static int do_startvl(struct cmd_tbl *cmdtp, int flag, int argc, char * const ar
 	cfg = sclr_disp_get_cfg();
 
 	if (intf_type == SCLR_VO_INTF_MIPI || intf_type == SCLR_VO_INTF_LVDS) {
-		cfg->fmt = SCL_FMT_YUV420;
-		cfg->in_csc = SCL_CSC_601_LIMIT_YUV2RGB;
+		unsigned char *in = (unsigned char *)(addr_in);
+		unsigned char *out = (unsigned char *)(addr_out);
+		unsigned short h = (*(in + 25) << 24) | (*(in + 24) << 16) | (*(in + 23) << 8) | *(in + 22);
+		unsigned short w = (*(in + 21) << 24) | (*(in + 20) << 16) | (*(in + 19) << 8) | *(in + 18);
+
+		printf("%c, %c, w:%d, h:%d\n", *in, *(in + 1), w, h);
+		printf("in:%p, out:%p\n", in, out);
+
+		rect.w = w;
+		rect.h = h;
+		stride = ALIGN(rect.w * 3, align);
+
+		rect.y = (timing->vmde_end - timing->vmde_start + 1 - rect.h) / 2;
+		rect.x = (timing->hmde_end - timing->hmde_start + 1 - rect.w) / 2;
+
+		sclr_disp_set_rect(rect);
+		cfg = sclr_disp_get_cfg();
+
+		cfg->fmt = SCL_FMT_RGB_PACKED;
+		cfg->in_csc = SCL_CSC_NONE;
 		cfg->mem.width = rect.w;
 		cfg->mem.height = rect.h;
-		cfg->mem.pitch_y = ALIGN(stride, 32);
-		cfg->mem.pitch_c = ALIGN(stride >> 1, 32);
+		cfg->mem.pitch_y = ALIGN(stride, align);
+		cfg->mem.pitch_c = 0;
+
+		if (*(in) == 'B' && *(in + 1) == 'M') {
+			printf("this is a bmp && %d*%d\n", w, h);
+			in = in + 54;	 //Remove the bmp header
+			for (unsigned short y = 0; y < h; ++y) {
+				for (unsigned short x = 0; x < w; ++x) {
+					out[y * stride + x * 3 + 0] = in[(h-1-y) * stride + x * 3 + 2];
+					out[y * stride + x * 3 + 1] = in[(h-1-y) * stride + x * 3 + 1];
+					out[y * stride + x * 3 + 2] = in[(h-1-y) * stride + x * 3 + 0];
+				}
+			}
+		} else {
+			printf("no bmp or rect not match, display red!\n");
+			for (int idx = 0; idx < rect.w * rect.h * 3;) {
+				*(out + idx) = 0xff;idx++;
+				*(out + idx) = 0;idx++;
+				*(out + idx) = 0;idx++;
+			}
+		}
 	} else if (intf_type == SCLR_VO_INTF_I80) {
 		unsigned char *in = (unsigned char *)(addr_in);
 		unsigned char *out = (unsigned char *)(addr_out);
diff --git a/u-boot-2021.10/include/configs/mars-asic.h b/u-boot-2021.10/include/configs/mars-asic.h
index 09dea9b2a..571f0e032 100644
--- a/u-boot-2021.10/include/configs/mars-asic.h
+++ b/u-boot-2021.10/include/configs/mars-asic.h
@@ -283,9 +283,9 @@
 		#elif defined(CONFIG_SPI_FLASH)
 			#define LOAD_LOGO "sf probe;sf read " LOGO_READ_ADDR " ${MISC_PART_OFFSET} ${MISC_PART_SIZE};"
 		#else
-			#define LOAD_LOGO "mmc dev 0;load mmc 0:1 " LOGO_READ_ADDR " logo.jpeg ;"
+			#define LOAD_LOGO "mmc dev 0;load mmc 0:1 " LOGO_READ_ADDR " logo.bmp ;"
 		#endif
-		#define SHOWLOGOCOMMAND LOAD_LOGO CVI_JPEG START_VO START_VL SET_VO_BG
+		#define SHOWLOGOCOMMAND LOAD_LOGO START_VO START_VL SET_VO_BG
 	#else
 		#define SHOWLOGOCMD
 	#endif

```



**A suggestion** 
By the way, I think maybe it's time to add riscv TAB and risc-v TAB to the tilck project home page, and modify the README file to remove the statement that tilck only supports x86 architecture and include a description of tilck's support for riscv. This will help attract a wide range **embedded software developers** to learn and participate in this project.


