### PR TITLE
[riscv64][bsp] fix broken build_toolchain due to PATH

### DIFF
--- a/other/bsp/riscv64/licheerv-nano/bootloader
+++ b/other/bsp/riscv64/licheerv-nano/bootloader
@@ -5,12 +5,16 @@ function internal_build_bootloader {
 
    echo "Building bootloader... "
    reset_cc_vars_to_null
+   local saved_path="$PATH"
+   export PATH=${PATH//$GCC_TOOLCHAIN:/}
 
    set +e
    run_command2 "source build/cvisetup.sh" build.log
    run_command2 "defconfig sg2002_licheervnano_sd" build.log
    run_command2 "build_uboot" build.log
    set -e
+
+   export PATH="$saved_path"
 }
 
 #


### PR DESCRIPTION
@vvaltchev 

I'm sorry that I missed the PATH problem in the build_toolchain. When building licheerv-nano's bootloader, it cannot include the PATH of the toolchain's bin, because it need to use the host system's python instead of the python under the toolchain's bin.

Now I have retested the whole process starting with 'git clone' and everything is working fine.
