### PR TITLE
[riscv64] Turn off the qemu ramfb option when testing

### DIFF
--- a/tests/runners/single_test_run
+++ b/tests/runners/single_test_run
@@ -243,7 +243,13 @@ def run_the_vm():
    global g_gcda_buf
    global g_gcda_file
 
-   arch_opts = "@QEMU_ARCH_OPTS@".split(' ')
+   arch_opts_str = "@QEMU_ARCH_OPTS@"
+   if ARCH in ['riscv64']:
+      arch_opts_str = arch_opts_str.replace("-serial stdio ", "")
+      arch_opts_str = arch_opts_str.replace("-device ramfb ", "")
+
+   arch_opts = arch_opts_str.split(' ')
+
    args = [
       'qemu-system-@ARCH@',
       '-m', str(VM_MEMORY_SIZE_IN_MB),


### PR DESCRIPTION
We need to merge this change first and then look at the ramfb one
